### PR TITLE
Fix #26: Remove duplicate libraries from About screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -142,7 +142,12 @@ dependencies {
 }
 
 aboutLibraries {
-    android.registerAndroidTasks = true
+    library {
+        // Enable the duplication mode, allows to merge, or link dependencies which relate
+        duplicationMode = com.mikepenz.aboutlibraries.plugin.DuplicateMode.MERGE
+        // Configure the duplication rule, to match "duplicates" with
+        duplicationRule = com.mikepenz.aboutlibraries.plugin.DuplicateRule.SIMPLE
+    }
 }
 
 protobuf {


### PR DESCRIPTION
## Description
This PR fixes the bug described in **issue #26**.

The issue was caused by the  **AboutLibraries** which collects and displays dependencies used in the app. It was listing some libraries multiple times — even when they were the same version — which led to duplicate entries in the About screen.

## Fixes
**AboutLibraries** provides some Gradle Plugin Configuration Options which includes
-  ***duplicationMode***
-  ***duplicationRule*** 

You can find more details in the [README File of **AboutLibraries**](https://github.com/mikepenz/AboutLibraries/blob/develop/README.md)

## Screenshots
<img width="720" height="1520" alt="image" src="https://github.com/user-attachments/assets/a834adff-1e0e-42df-a3b7-16f0ecdc9ccc" />


## Linked Issue

Closes #26