### PR TITLE
Offer x86_64 build again

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 val abiCodes = mapOf(
     "arm64-v8a" to 0,
     "armeabi-v7a" to -1,
+    "x86_64" to -2,
 )
 
 android {
@@ -25,7 +26,7 @@ android {
         // https://ai.google.dev/edge/litert/android/index
         minSdk = 26
         targetSdk = 36
-        versionCode = 42 // increment by 2 because of ABI-specific APKs
+        versionCode = 43 // increment by 3 because of ABI-specific APKs
         versionName = "1.11.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
This build variant is very helpful for testing on emulators.
Given that since d991c42f the apks are split by ABI, this also doesn't have a detrimental impact on the installation experience.