### PR TITLE
Original source image of a page is now stored in correct orientation

### DIFF
--- a/app/src/main/java/org/fairscan/app/data/DocumentMetadata.kt
+++ b/app/src/main/java/org/fairscan/app/data/DocumentMetadata.kt
@@ -36,7 +36,6 @@ data class DocumentMetadataV2(
 @Serializable
 data class PageV2(
     val id: String,
-    val baseRotationDegrees: Int = 0,
     val manualRotationDegrees: Int = 0,
     val quad: NormalizedQuad? = null,
     val isColored: Boolean? = null

--- a/app/src/main/java/org/fairscan/app/data/ImageRepository.kt
+++ b/app/src/main/java/org/fairscan/app/data/ImageRepository.kt
@@ -142,7 +142,6 @@ class ImageRepository(
             PageV2(
                 id = id,
                 quad = metadata.normalizedQuad.toSerializable(),
-                baseRotationDegrees = metadata.baseRotation.degrees,
                 manualRotationDegrees = Rotation.R0.degrees,
                 isColored = metadata.isColored
             )
@@ -327,7 +326,6 @@ fun PageV2.toMetadata(): PageMetadata? {
     if (quad == null || isColored == null) return null
     return PageMetadata(
         quad.toQuad(),
-        Rotation.fromDegrees(baseRotationDegrees),
         isColored
     )
 }

--- a/app/src/main/java/org/fairscan/app/domain/ExportPreparation.kt
+++ b/app/src/main/java/org/fairscan/app/domain/ExportPreparation.kt
@@ -86,7 +86,7 @@ fun prepareJpegForHigh(
     val page = extractDocument(
         decoded,
         quad,
-        pageMetadata.baseRotation.add(manualRotation).degrees,
+        manualRotation.degrees,
         pageMetadata.isColored,
         exportQuality.maxPixels)
     val outJpegBytes = encodeJpeg(page, exportQuality.jpegQuality)

--- a/app/src/main/java/org/fairscan/app/domain/Page.kt
+++ b/app/src/main/java/org/fairscan/app/domain/Page.kt
@@ -18,7 +18,6 @@ import org.fairscan.imageprocessing.Quad
 
 data class PageMetadata(
     val normalizedQuad: Quad,
-    val baseRotation: Rotation,
     val isColored: Boolean,
 )
 

--- a/app/src/main/java/org/fairscan/app/ui/screens/camera/CameraScreen.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/camera/CameraScreen.kt
@@ -537,7 +537,7 @@ fun CameraScreenPreviewWithProcessedImage() {
         CapturedPage(
             debugImage("gallica.bnf.fr-bpt6k5530456s-1.jpg"),
             debugImage("gallica.bnf.fr-bpt6k5530456s-1.jpg"),
-            PageMetadata(quad, R0, false))))
+            PageMetadata(quad, false))))
 }
 
 @Preview(showBackground = true, widthDp = 640, heightDp = 320)

--- a/app/src/test/java/org/fairscan/app/data/ImageRepositoryTest.kt
+++ b/app/src/test/java/org/fairscan/app/data/ImageRepositoryTest.kt
@@ -38,7 +38,7 @@ class ImageRepositoryTest {
     private var _filesDir: File? = null
 
     val quad1 = Quad(Point(.01, .02), Point(.1, .03), Point(.11, .12), Point(.03, .09))
-    val metadata1 = PageMetadata(quad1, R90, true)
+    val metadata1 = PageMetadata(quad1, true)
 
     fun getFilesDir(): File {
         if (_filesDir == null) {
@@ -77,7 +77,6 @@ class ImageRepositoryTest {
         val metadata = page.metadata
         assertThat(metadata).isNotNull()
         assertThat(metadata!!.normalizedQuad).isEqualTo(quad1)
-        assertThat(metadata.baseRotation).isEqualTo(metadata1.baseRotation)
         assertThat(metadata.isColored).isEqualTo(metadata1.isColored)
     }
 
@@ -239,11 +238,11 @@ class ImageRepositoryTest {
     fun metadata() {
         val quad = quad1.toSerializable()
 
-        assertThat(PageV2("1", 0, 0, null,true).toMetadata()).isNull()
-        assertThat(PageV2("1", 0, 0, quad, null).toMetadata()).isNull()
+        assertThat(PageV2("1", 0, null,true).toMetadata()).isNull()
+        assertThat(PageV2("1", 0, quad, null).toMetadata()).isNull()
 
         listOf(true, false).forEach { isColored ->
-            val metadata = PageV2("1", 0, 0, quad, isColored).toMetadata()
+            val metadata = PageV2("1", 0, quad, isColored).toMetadata()
             assertThat(metadata).isNotNull()
             assertThat(metadata!!.isColored).isEqualTo(isColored)
         }

--- a/app/src/test/java/org/fairscan/app/data/PageStoreTest.kt
+++ b/app/src/test/java/org/fairscan/app/data/PageStoreTest.kt
@@ -55,10 +55,10 @@ class PageStoreTest {
 
     @Test
     fun update() {
-        val page = PageV2("3", baseRotationDegrees = 90)
+        val page = PageV2("3", manualRotationDegrees = 90)
         val store = PageStore(listOf(page))
-        store.update(page.id) { p -> p.copy(baseRotationDegrees = p.baseRotationDegrees + 180) }
-        assertThat(store.get(page.id)!!.baseRotationDegrees).isEqualTo(270)
+        store.update(page.id) { p -> p.copy(manualRotationDegrees = p.manualRotationDegrees + 180) }
+        assertThat(store.get(page.id)!!.manualRotationDegrees).isEqualTo(270)
     }
 
     @Test


### PR DESCRIPTION
This way, when sharing the original image or for other downstream uses, it is correctly oriented. And getting rid of the `baseRotation` makes the code less complex.

For this to work, the image as well as the quad are rotated, so the data stays in sync.