### PR TITLE
Fix reporting email for images scanned via Intent

### DIFF
--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -10,4 +10,8 @@
     <files-path
         name="sources"
         path="sources/" />
+    <!-- source images, when scanning via Intent (to send the last captured image) -->
+    <cache-path
+        name="session_sources"
+        path="sessions/" />
 </paths>


### PR DESCRIPTION
When starting the app via "org.fairscan.app.action.SCAN_TO_PDF" and then reporting the last image via createEmailWithImageIntent() the URI creation failed with

> java.lang.IllegalArgumentException: Failed to find configured root that contains /data/data/org.fairscan.app/cache/sessions/097d29ab-f706-4ba2-848a-fea16fb5f41f/sources/1776590719661.jpg

The issue was that when launched via SCAN_TO_PDF, images are stored under the cache directory (cache/sessions/<uuid>/sources/), but the FileProvider configuration in file_paths.xml only had a <cache-path> for pdfs/ and <files-path> for sources/. There was no cache path covering sessions/.