### PR TITLE
New feature: Optional manual adjustment of quad

### DIFF
--- a/LICENSE_HEADER
+++ b/LICENSE_HEADER
@@ -1,4 +1,3 @@
-Copyright 2025-2026 Pierre-Yves Nicolas
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by the Free

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ And **respectful**: open source, minimal permissions, no tracking, no ads.
 - **Clear, distraction-free interface**
 - **Easy flow**: scan, review if needed, save or share
 - **Automatic document detection** using a custom segmentation model
-- **Automatic perspective correction**
+- **Automatic perspective correction** with optional manual adjustments
 - **Automatic image enhancement**
 - **Fast PDF generation** with no manual adjustments
 - **Fully offline** – the app has *no* internet permission

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ When started via this intent:
 - the resulting PDF is returned to the calling application as a URI with a limited lifetime
 - the calling application should immediately copy the content of the URI as FairScan deletes it later
 
+Optional boolean extra: `org.fairscan.app.extra.EDIT_MODE`
+- when set to `true`, the image editing screen is enabled for this invocation, regardless of the user's app setting.
+- when set to `false`, the image editing screen is disabled for this invocation, regardless of the user's app setting.
+- when the extra is **not provided**, the app's own setting is used.
+
+This extra does **not** change the persisted app setting.
+
 See an example app: [fairscan-intent-sample](https://github.com/pynicolas/fairscan-intent-sample)
 
 ---

--- a/app/src/main/java/org/fairscan/app/MainActivity.kt
+++ b/app/src/main/java/org/fairscan/app/MainActivity.kt
@@ -54,6 +54,7 @@ import org.fairscan.app.ui.Navigation
 import org.fairscan.app.ui.Screen
 import org.fairscan.app.ui.components.rememberCameraPermissionState
 import org.fairscan.app.ui.screens.DocumentScreen
+import org.fairscan.app.ui.screens.edit.EditPageScreen
 import org.fairscan.app.ui.screens.LibrariesScreen
 import org.fairscan.app.ui.screens.about.AboutEvent
 import org.fairscan.app.ui.screens.about.AboutScreen
@@ -173,6 +174,13 @@ class MainActivity : ComponentActivity() {
                             onImageAnalyzed = { image -> cameraViewModel.liveAnalysis(image) },
                             onFinalizePressed = onExportClick,
                             cameraPermission = cameraPermission
+                        )
+                    }
+                    is Screen.Main.EditImage -> {
+                        EditPageScreen(
+                            pageId = document.pageId(screen.pageIndex),
+                            imageRepository = imageRepository,
+                            navigation = navigation
                         )
                     }
                     is Screen.Main.Document -> {
@@ -449,6 +457,7 @@ class MainActivity : ComponentActivity() {
     private fun navigation(viewModel: MainViewModel, launchMode: LaunchMode): Navigation = Navigation(
         toHomeScreen = { viewModel.navigateTo(Screen.Main.Home) },
         toCameraScreen = { viewModel.navigateTo(Screen.Main.Camera) },
+        toEditImageScreen = { pageIndex -> viewModel.navigateTo(Screen.Main.EditImage(pageIndex)) },
         toDocumentScreen = { viewModel.navigateTo(Screen.Main.Document()) },
         toExportScreen = { viewModel.navigateTo(Screen.Main.Export) },
         toAboutScreen = { viewModel.navigateTo(Screen.Overlay.About) },

--- a/app/src/main/java/org/fairscan/app/MainActivity.kt
+++ b/app/src/main/java/org/fairscan/app/MainActivity.kt
@@ -174,7 +174,8 @@ class MainActivity : ComponentActivity() {
                             liveAnalysisState,
                             onImageAnalyzed = { image -> cameraViewModel.liveAnalysis(image) },
                             onFinalizePressed = onExportClick,
-                            cameraPermission = cameraPermission
+                            cameraPermission = cameraPermission,
+                            imageEditingEnabled = settingsUiState.imageEditingEnabled,
                         )
                     }
                     is Screen.Main.EditImage -> {
@@ -368,6 +369,10 @@ class MainActivity : ComponentActivity() {
             cameraViewModel.events.collect { event ->
                 when (event) {
                     is CameraEvent.ImageCaptured -> viewModel.handleImageCaptured(event.page)
+                    is CameraEvent.ImageCapturedForEditing -> {
+                        val pageIndex = viewModel.addPageAndGetIndex(event.page)
+                        viewModel.navigateTo(Screen.Main.EditImage(pageIndex))
+                    }
                 }
             }
         }

--- a/app/src/main/java/org/fairscan/app/MainActivity.kt
+++ b/app/src/main/java/org/fairscan/app/MainActivity.kt
@@ -77,6 +77,9 @@ import org.fairscan.app.ui.theme.FairScanTheme
 import org.opencv.android.OpenCVLoader
 import java.io.File
 
+private const val INTENT_ACTION_SCAN = "org.fairscan.app.action.SCAN_TO_PDF"
+private const val EXTRA_EDIT_MODE = "org.fairscan.app.extra.EDIT_MODE"
+
 class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -85,6 +88,11 @@ class MainActivity : ComponentActivity() {
 
         val appContainer = (application as FairScanApp).appContainer
         val launchMode = resolveLaunchMode(intent)
+        val intentEditMode: Boolean? =
+            if (launchMode == LaunchMode.EXTERNAL_SCAN_TO_PDF
+                && intent?.hasExtra(EXTRA_EDIT_MODE) == true)
+                intent.getBooleanExtra(EXTRA_EDIT_MODE, false)
+            else null
 
         val sessionViewModel: SessionViewModel by viewModels {
             SessionViewModelFactory(
@@ -126,6 +134,7 @@ class MainActivity : ComponentActivity() {
             val document by viewModel.documentUiModel.collectAsStateWithLifecycle()
             val exportUiState by exportViewModel.uiState.collectAsStateWithLifecycle()
             val settingsUiState by settingsViewModel.uiState.collectAsStateWithLifecycle()
+            val imageEditingEnabled = intentEditMode ?: settingsUiState.imageEditingEnabled
             val cameraPermission = rememberCameraPermissionState()
             CollectCameraEvents(cameraViewModel, viewModel)
             CollectExportEvents(context, exportViewModel)
@@ -175,7 +184,7 @@ class MainActivity : ComponentActivity() {
                             onImageAnalyzed = { image -> cameraViewModel.liveAnalysis(image) },
                             onFinalizePressed = onExportClick,
                             cameraPermission = cameraPermission,
-                            imageEditingEnabled = settingsUiState.imageEditingEnabled,
+                            imageEditingEnabled = imageEditingEnabled,
                         )
                     }
                     is Screen.Main.EditImage -> {
@@ -201,7 +210,7 @@ class MainActivity : ComponentActivity() {
                             onDeleteImage =  { id -> viewModel.deletePage(id) },
                             onRotateImage = { id, clockwise -> viewModel.rotateImage(id, clockwise) },
                             onPageReorder = { id, newIndex -> viewModel.movePage(id, newIndex) },
-                            showEditButton = settingsUiState.imageEditingEnabled,
+                            showEditButton = imageEditingEnabled,
                         )
                     }
                     is Screen.Main.Export -> {
@@ -249,7 +258,7 @@ class MainActivity : ComponentActivity() {
 
     private fun resolveLaunchMode(intent: Intent?): LaunchMode {
         return when (intent?.action) {
-            "org.fairscan.app.action.SCAN_TO_PDF" -> LaunchMode.EXTERNAL_SCAN_TO_PDF
+            INTENT_ACTION_SCAN -> LaunchMode.EXTERNAL_SCAN_TO_PDF
             else -> LaunchMode.NORMAL
         }
     }

--- a/app/src/main/java/org/fairscan/app/MainActivity.kt
+++ b/app/src/main/java/org/fairscan/app/MainActivity.kt
@@ -180,7 +180,8 @@ class MainActivity : ComponentActivity() {
                         EditPageScreen(
                             pageId = document.pageId(screen.pageIndex),
                             imageRepository = imageRepository,
-                            navigation = navigation
+                            navigation = navigation,
+                            onUpdatePageQuad = { id, quad -> viewModel.updatePageQuad(id, quad) }
                         )
                     }
                     is Screen.Main.Document -> {

--- a/app/src/main/java/org/fairscan/app/MainActivity.kt
+++ b/app/src/main/java/org/fairscan/app/MainActivity.kt
@@ -182,7 +182,13 @@ class MainActivity : ComponentActivity() {
                             pageId = document.pageId(screen.pageIndex),
                             imageRepository = imageRepository,
                             navigation = navigation,
-                            onUpdatePageQuad = { id, quad, onComplete -> viewModel.updatePageQuad(id, quad, onComplete) }
+                            onUpdatePageQuad = { id, quad, onComplete -> viewModel.updatePageQuad(id, quad, onComplete) },
+                            onReportProblem = {
+                                val file = imageRepository.getSourceFile(document.pageId(screen.pageIndex))
+                                if (file.exists()) {
+                                    startActivity(createEmailWithImageIntent(context, file))
+                                }
+                            }
                         )
                     }
                     is Screen.Main.Document -> {

--- a/app/src/main/java/org/fairscan/app/MainActivity.kt
+++ b/app/src/main/java/org/fairscan/app/MainActivity.kt
@@ -125,6 +125,7 @@ class MainActivity : ComponentActivity() {
             val liveAnalysisState by cameraViewModel.liveAnalysisState.collectAsStateWithLifecycle()
             val document by viewModel.documentUiModel.collectAsStateWithLifecycle()
             val exportUiState by exportViewModel.uiState.collectAsStateWithLifecycle()
+            val settingsUiState by settingsViewModel.uiState.collectAsStateWithLifecycle()
             val cameraPermission = rememberCameraPermissionState()
             CollectCameraEvents(cameraViewModel, viewModel)
             CollectExportEvents(context, exportViewModel)
@@ -193,6 +194,7 @@ class MainActivity : ComponentActivity() {
                             onDeleteImage =  { id -> viewModel.deletePage(id) },
                             onRotateImage = { id, clockwise -> viewModel.rotateImage(id, clockwise) },
                             onPageReorder = { id, newIndex -> viewModel.movePage(id, newIndex) },
+                            showEditButton = settingsUiState.imageEditingEnabled,
                         )
                     }
                     is Screen.Main.Export -> {
@@ -288,6 +290,7 @@ class MainActivity : ComponentActivity() {
             onResetExportDirClick = { settingsViewModel.setExportDirUri(null) },
             onExportFormatChanged = { format -> settingsViewModel.setExportFormat(format) },
             onExportQualityChanged = { quality -> settingsViewModel.setExportQuality(quality) },
+            onImageEditingEnabledChanged = { enabled -> settingsViewModel.setImageEditingEnabled(enabled) },
             onBack = nav.back,
         )
     }

--- a/app/src/main/java/org/fairscan/app/MainActivity.kt
+++ b/app/src/main/java/org/fairscan/app/MainActivity.kt
@@ -182,7 +182,7 @@ class MainActivity : ComponentActivity() {
                             pageId = document.pageId(screen.pageIndex),
                             imageRepository = imageRepository,
                             navigation = navigation,
-                            onUpdatePageQuad = { id, quad -> viewModel.updatePageQuad(id, quad) }
+                            onUpdatePageQuad = { id, quad, onComplete -> viewModel.updatePageQuad(id, quad, onComplete) }
                         )
                     }
                     is Screen.Main.Document -> {

--- a/app/src/main/java/org/fairscan/app/MainViewModel.kt
+++ b/app/src/main/java/org/fairscan/app/MainViewModel.kt
@@ -36,6 +36,7 @@ import org.fairscan.app.domain.ScanPage
 import org.fairscan.app.ui.NavigationState
 import org.fairscan.app.ui.Screen
 import org.fairscan.app.ui.state.DocumentUiModel
+import org.fairscan.imageprocessing.Quad
 
 class MainViewModel(val imageRepository: ImageRepository, launchMode: LaunchMode): ViewModel() {
 
@@ -99,6 +100,15 @@ class MainViewModel(val imageRepository: ImageRepository, launchMode: LaunchMode
                 imageRepository.pages()
             }
             _pages.value = pages
+        }
+    }
+
+    fun updatePageQuad(id: String, newQuad: Quad) {
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                imageRepository.updatePageQuad(id, newQuad)
+            }
+            _pages.value = imageRepository.pages()
         }
     }
 

--- a/app/src/main/java/org/fairscan/app/MainViewModel.kt
+++ b/app/src/main/java/org/fairscan/app/MainViewModel.kt
@@ -134,16 +134,25 @@ class MainViewModel(val imageRepository: ImageRepository, launchMode: LaunchMode
 
     fun handleImageCaptured(capturedPage: CapturedPage) {
         viewModelScope.launch {
-            val pages = withContext(Dispatchers.IO) {
-                val sourceJpeg = capturedPage.sourceJpeg.await()
-                imageRepository.add(
-                    capturedPage.pageJpeg,
-                    sourceJpeg,
-                    capturedPage.metadata,
-                )
-                imageRepository.pages()
-            }
-            _pages.value = pages
+            addPage(capturedPage)
         }
+    }
+
+    suspend fun addPageAndGetIndex(capturedPage: CapturedPage): Int {
+        return addPage(capturedPage)
+    }
+
+    private suspend fun addPage(capturedPage: CapturedPage): Int {
+        val pages = withContext(Dispatchers.IO) {
+            val sourceJpeg = capturedPage.sourceJpeg.await()
+            imageRepository.add(
+                capturedPage.pageJpeg,
+                sourceJpeg,
+                capturedPage.metadata,
+            )
+            imageRepository.pages()
+        }
+        _pages.value = pages
+        return pages.size - 1
     }
 }

--- a/app/src/main/java/org/fairscan/app/MainViewModel.kt
+++ b/app/src/main/java/org/fairscan/app/MainViewModel.kt
@@ -103,12 +103,13 @@ class MainViewModel(val imageRepository: ImageRepository, launchMode: LaunchMode
         }
     }
 
-    fun updatePageQuad(id: String, newQuad: Quad) {
+    fun updatePageQuad(id: String, newQuad: Quad, onComplete: () -> Unit = {}) {
         viewModelScope.launch {
             withContext(Dispatchers.IO) {
                 imageRepository.updatePageQuad(id, newQuad)
             }
             _pages.value = imageRepository.pages()
+            onComplete()
         }
     }
 

--- a/app/src/main/java/org/fairscan/app/data/ImageRepository.kt
+++ b/app/src/main/java/org/fairscan/app/data/ImageRepository.kt
@@ -203,7 +203,7 @@ class ImageRepository(
         return if (file.exists()) file.readBytes() else null
     }
 
-    private fun getSourceFile(id: String): File {
+    fun getSourceFile(id: String): File {
         return File(sourceDir, "$id.jpg")
     }
 

--- a/app/src/main/java/org/fairscan/app/data/ImageRepository.kt
+++ b/app/src/main/java/org/fairscan/app/data/ImageRepository.kt
@@ -299,6 +299,58 @@ class ImageRepository(
     fun getPageMetadata(id: String): PageMetadata? {
         return pages.get(id)?.toMetadata()
     }
+
+    fun updatePageQuad(id: String, newQuad: Quad) {
+        val page = pages.get(id) ?: return
+
+        // Update metadata with new quad
+        pages.update(id) {
+            it.copy(quad = newQuad.toSerializable())
+        }
+        saveMetadata()
+
+        // Regenerate the processed page image with the new quad
+        val sourceFile = getSourceFile(id)
+        if (!sourceFile.exists()) {
+            return
+        }
+
+        val workFile = File(scanDir, page.workFileName())
+        transformations.extractDocument(
+            sourceFile,
+            workFile,
+            newQuad,
+            page.manualRotationDegrees,
+            page.isColored == true,
+            ExportQuality.BALANCED
+        )
+        writeThumbnail(workFile)
+
+        val r0WorkFile = File(scanDir, workFileName(id, Rotation.R0))
+
+        if (page.manualRotationDegrees != Rotation.R0.degrees) {
+            // Also need to recreate the 0-degree variant as this is the basis for other re-computations
+            transformations.extractDocument(
+                sourceFile,
+                r0WorkFile,
+                newQuad,
+                Rotation.R0.degrees,
+                page.isColored == true,
+                ExportQuality.BALANCED
+            )
+            writeThumbnail(r0WorkFile)
+        }
+
+        // Delete all others so they are properly re-generated upon next access
+        scanDir.listFiles()
+            ?.filter { it.name.startsWith("${id}.") || it.name.startsWith("$id-")}
+            ?.filter { it.name != page.workFileName() && it.name != r0WorkFile.name }
+            ?.forEach { it.delete() }
+        thumbnailDir.listFiles()
+            ?.filter { it.name.startsWith("${id}.") || it.name.startsWith("$id-") }
+            ?.filter { it.name != page.workFileName() && it.name != r0WorkFile.name }
+            ?.forEach { it.delete() }
+    }
 }
 
 fun Quad.toSerializable(): NormalizedQuad =

--- a/app/src/main/java/org/fairscan/app/data/ImageRepository.kt
+++ b/app/src/main/java/org/fairscan/app/data/ImageRepository.kt
@@ -300,6 +300,11 @@ class ImageRepository(
         return pages.get(id)?.toMetadata()
     }
 
+    fun getManualRotation(id: String): Rotation {
+        val degrees = pages.get(id)?.manualRotationDegrees ?: 0
+        return Rotation.fromDegrees(degrees)
+    }
+
     fun updatePageQuad(id: String, newQuad: Quad) {
         val page = pages.get(id) ?: return
 
@@ -315,12 +320,16 @@ class ImageRepository(
             return
         }
 
+        val baseRotation = Rotation.fromDegrees(page.baseRotationDegrees)
+        val manualRotation = Rotation.fromDegrees(page.manualRotationDegrees)
+        val totalRotation = baseRotation.add(manualRotation)
+
         val workFile = File(scanDir, page.workFileName())
         transformations.extractDocument(
             sourceFile,
             workFile,
             newQuad,
-            page.manualRotationDegrees,
+            totalRotation.degrees,
             page.isColored == true,
             ExportQuality.BALANCED
         )
@@ -334,7 +343,7 @@ class ImageRepository(
                 sourceFile,
                 r0WorkFile,
                 newQuad,
-                Rotation.R0.degrees,
+                baseRotation.degrees,
                 page.isColored == true,
                 ExportQuality.BALANCED
             )

--- a/app/src/main/java/org/fairscan/app/data/ImageRepository.kt
+++ b/app/src/main/java/org/fairscan/app/data/ImageRepository.kt
@@ -295,6 +295,10 @@ class ImageRepository(
         }
         return sourceFiles.maxByOrNull { it.lastModified() }
     }
+
+    fun getPageMetadata(id: String): PageMetadata? {
+        return pages.get(id)?.toMetadata()
+    }
 }
 
 fun Quad.toSerializable(): NormalizedQuad =

--- a/app/src/main/java/org/fairscan/app/data/ImageTransformations.kt
+++ b/app/src/main/java/org/fairscan/app/data/ImageTransformations.kt
@@ -14,6 +14,8 @@
  */
 package org.fairscan.app.data
 
+import org.fairscan.app.domain.ExportQuality
+import org.fairscan.imageprocessing.Quad
 import java.io.File
 
 interface ImageTransformations {
@@ -22,4 +24,5 @@ interface ImageTransformations {
 
     fun resize(inputFile: File, outputFile: File, maxSize: Int)
 
+    fun extractDocument( inputFile: File, outputFile: File, normalizedQuad: Quad, rotationDegrees: Int, isColored: Boolean, quality: ExportQuality)
 }

--- a/app/src/main/java/org/fairscan/app/platform/OpenCvImageTransformations.kt
+++ b/app/src/main/java/org/fairscan/app/platform/OpenCvImageTransformations.kt
@@ -15,8 +15,12 @@
 package org.fairscan.app.platform
 
 import org.fairscan.app.data.ImageTransformations
+import org.fairscan.app.domain.ExportQuality
+import org.fairscan.imageprocessing.Quad
 import org.fairscan.imageprocessing.encodeJpeg
+import org.fairscan.imageprocessing.scaledTo
 import org.opencv.core.Mat
+import org.opencv.core.MatOfInt
 import org.opencv.core.Size
 import org.opencv.imgcodecs.Imgcodecs
 import org.opencv.imgproc.Imgproc
@@ -63,6 +67,43 @@ class OpenCvTransformations : ImageTransformations {
         } finally {
             input.release()
             output?.release()
+        }
+    }
+
+    override fun extractDocument(
+        inputFile: File,
+        outputFile: File,
+        normalizedQuad: Quad,
+        rotationDegrees: Int,
+        isColored: Boolean,
+        quality: ExportQuality
+    ) {
+        // Load source image
+        val src = Imgcodecs.imread(inputFile.absolutePath)
+        require(!src.empty()) { "Could not load image from ${inputFile.absolutePath}" }
+
+        var extracted: Mat? = null
+        var params: MatOfInt? = null
+        try {
+            val quad = normalizedQuad.scaledTo(1, 1, src.width(), src.height())
+
+            extracted = org.fairscan.imageprocessing.extractDocument(
+                src,
+                quad,
+                rotationDegrees,
+                isColored,
+                quality.maxPixels
+            )
+
+            // Save result as JPEG
+            params = MatOfInt(Imgcodecs.IMWRITE_JPEG_QUALITY, quality.jpegQuality)
+            if (!Imgcodecs.imwrite(outputFile.absolutePath, extracted, params)) {
+                throw RuntimeException("Could not write image to ${outputFile.absolutePath}")
+            }
+        } finally {
+            params?.release()
+            extracted?.release()
+            src.release()
         }
     }
 }

--- a/app/src/main/java/org/fairscan/app/ui/Navigation.kt
+++ b/app/src/main/java/org/fairscan/app/ui/Navigation.kt
@@ -20,6 +20,7 @@ sealed class Screen {
     sealed class Main : Screen() {
         object Home : Main()
         object Camera : Main()
+        data class EditImage(val pageIndex: Int) : Main()
         data class Document(val initialPage: Int = 0) : Main()
         object Export : Main()
     }
@@ -33,6 +34,7 @@ sealed class Screen {
 data class Navigation(
     val toHomeScreen: () -> Unit,
     val toCameraScreen: () -> Unit,
+    val toEditImageScreen: (Int) -> Unit,
     val toDocumentScreen: () -> Unit,
     val toExportScreen: () -> Unit,
     val toAboutScreen: () -> Unit,
@@ -73,6 +75,7 @@ data class NavigationState private constructor(val stack: List<Screen>, val root
             is Screen.Main.Home -> this // Back handled by system
             is Screen.Main.Camera -> copy(stack = listOf(Screen.Main.Home))
             is Screen.Main.Document -> copy(stack = listOf(Screen.Main.Camera))
+            is Screen.Main.EditImage -> copy(stack = listOf(Screen.Main.Document(initialPage = (current as Screen.Main.EditImage).pageIndex)))
             is Screen.Main.Export -> copy(stack = listOf(Screen.Main.Camera))
             is Screen.Overlay -> copy(stack = stack.dropLast(1))
         }

--- a/app/src/main/java/org/fairscan/app/ui/PreviewUtils.kt
+++ b/app/src/main/java/org/fairscan/app/ui/PreviewUtils.kt
@@ -24,7 +24,7 @@ import org.fairscan.app.domain.Rotation
 import org.fairscan.app.ui.state.DocumentUiModel
 
 fun dummyNavigation(): Navigation {
-    return Navigation({}, {}, {}, {}, {}, {}, {}, {})
+    return Navigation({}, {}, {}, {}, {}, {}, {}, {}, {})
 }
 
 fun fakeDocument(): DocumentUiModel {

--- a/app/src/main/java/org/fairscan/app/ui/components/Buttons.kt
+++ b/app/src/main/java/org/fairscan/app/ui/components/Buttons.kt
@@ -14,6 +14,7 @@
  */
 package org.fairscan.app.ui.components
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -28,6 +29,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -56,15 +58,18 @@ fun SecondaryActionButton(
     icon: ImageVector,
     contentDescription: String,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
 ) {
     FilledIconButton (
         onClick = onClick,
         colors = IconButtonDefaults.outlinedIconButtonColors(
             containerColor = MaterialTheme.colorScheme.primaryContainer,
-            contentColor = MaterialTheme.colorScheme.primary
+            contentColor = MaterialTheme.colorScheme.primary,
+            disabledContainerColor = if (isSystemInDarkTheme()) Color.DarkGray else Color.LightGray
         ),
-        modifier = modifier.size(40.dp)
+        modifier = modifier.size(40.dp),
+        enabled = enabled
     ) {
         Icon(
             imageVector = icon,

--- a/app/src/main/java/org/fairscan/app/ui/components/Buttons.kt
+++ b/app/src/main/java/org/fairscan/app/ui/components/Buttons.kt
@@ -61,7 +61,7 @@ fun SecondaryActionButton(
     FilledIconButton (
         onClick = onClick,
         colors = IconButtonDefaults.outlinedIconButtonColors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.6f),
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
             contentColor = MaterialTheme.colorScheme.primary
         ),
         modifier = modifier.size(40.dp)

--- a/app/src/main/java/org/fairscan/app/ui/components/Scaffold.kt
+++ b/app/src/main/java/org/fairscan/app/ui/components/Scaffold.kt
@@ -152,6 +152,7 @@ fun isLandscape(configuration: Configuration): Boolean {
 fun AppOverflowMenu(
     navigation: Navigation,
     modifier: Modifier = Modifier,
+    extraItems: (@Composable (onDismiss: () -> Unit) -> Unit)? = null,
 ) {
     var expanded by remember { mutableStateOf(false) }
     Box(
@@ -171,6 +172,8 @@ fun AppOverflowMenu(
             modifier = Modifier
                 .background(MaterialTheme.colorScheme.surface)
         ) {
+
+            extraItems?.invoke { expanded = false }
 
             navigation.toSettingsScreen?.let { toSettings ->
                 DropdownMenuItem(

--- a/app/src/main/java/org/fairscan/app/ui/screens/DocumentScreen.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/DocumentScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.RotateLeft
 import androidx.compose.material.icons.filled.RotateRight
 import androidx.compose.material.icons.outlined.Add
@@ -125,6 +126,7 @@ fun DocumentScreen(
             currentPageIndex,
             { showDeletePageDialog.value = true },
             onRotateImage,
+            navigation.toEditImageScreen,
             modifier
         )
         if (showDeletePageDialog.value) {
@@ -143,6 +145,7 @@ private fun DocumentPreview(
     currentPageIndex: MutableIntState,
     onDeleteImage: (String) -> Unit,
     onRotateImage: (String, Boolean) -> Unit,
+    onEditImage: (Int) -> Unit,
     modifier: Modifier,
 ) {
     val imageId = document.pageId(currentPageIndex.intValue)
@@ -175,7 +178,7 @@ private fun DocumentPreview(
                     )
                 }
             }
-            RotationButtons(imageId, onRotateImage, Modifier.align(Alignment.BottomCenter))
+            RotationButtons(imageId, currentPageIndex.intValue, onRotateImage, onEditImage, Modifier.align(Alignment.BottomCenter))
             SecondaryActionButton(
                 Icons.Outlined.Delete,
                 contentDescription = stringResource(R.string.delete_page),
@@ -202,7 +205,9 @@ private fun DocumentPreview(
 @Composable
 fun RotationButtons(
     imageId: String,
+    pageIndex: Int,
     onRotateImage: (String, Boolean) -> Unit,
+    onEditImage: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     // RotateLeft on the left, RotateRight on the right: for both LTR and RTL languages
@@ -221,6 +226,12 @@ fun RotationButtons(
                 icon = Icons.Default.RotateRight,
                 contentDescription = stringResource(R.string.rotate_right),
                 onClick = { onRotateImage(imageId, true) }
+            )
+            Spacer(Modifier.width(8.dp))
+            SecondaryActionButton(
+                icon = Icons.Filled.Edit,
+                contentDescription = "Edit image",
+                onClick = { onEditImage(pageIndex) }
             )
         }
     }

--- a/app/src/main/java/org/fairscan/app/ui/screens/DocumentScreen.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/DocumentScreen.kt
@@ -88,6 +88,7 @@ fun DocumentScreen(
     onDeleteImage: (String) -> Unit,
     onRotateImage: (String, Boolean) -> Unit,
     onPageReorder: (String, Int) -> Unit,
+    showEditButton: Boolean = false,
 ) {
     // TODO Check how often images are loaded
     val showDeletePageDialog = rememberSaveable { mutableStateOf(false) }
@@ -127,6 +128,7 @@ fun DocumentScreen(
             { showDeletePageDialog.value = true },
             onRotateImage,
             navigation.toEditImageScreen,
+            showEditButton,
             modifier
         )
         if (showDeletePageDialog.value) {
@@ -146,6 +148,7 @@ private fun DocumentPreview(
     onDeleteImage: (String) -> Unit,
     onRotateImage: (String, Boolean) -> Unit,
     onEditImage: (Int) -> Unit,
+    showEditButton: Boolean,
     modifier: Modifier,
 ) {
     val imageId = document.pageId(currentPageIndex.intValue)
@@ -178,7 +181,7 @@ private fun DocumentPreview(
                     )
                 }
             }
-            RotationButtons(imageId, currentPageIndex.intValue, onRotateImage, onEditImage, Modifier.align(Alignment.BottomCenter))
+            RotationButtons(imageId, currentPageIndex.intValue, onRotateImage, onEditImage, showEditButton, Modifier.align(Alignment.BottomCenter))
             SecondaryActionButton(
                 Icons.Outlined.Delete,
                 contentDescription = stringResource(R.string.delete_page),
@@ -208,6 +211,7 @@ fun RotationButtons(
     pageIndex: Int,
     onRotateImage: (String, Boolean) -> Unit,
     onEditImage: (Int) -> Unit,
+    showEditButton: Boolean,
     modifier: Modifier = Modifier
 ) {
     // RotateLeft on the left, RotateRight on the right: for both LTR and RTL languages
@@ -227,12 +231,14 @@ fun RotationButtons(
                 contentDescription = stringResource(R.string.rotate_right),
                 onClick = { onRotateImage(imageId, true) }
             )
-            Spacer(Modifier.width(8.dp))
-            SecondaryActionButton(
-                icon = Icons.Filled.Edit,
-                contentDescription = "Edit image",
-                onClick = { onEditImage(pageIndex) }
-            )
+            if (showEditButton) {
+                Spacer(Modifier.width(8.dp))
+                SecondaryActionButton(
+                    icon = Icons.Filled.Edit,
+                    contentDescription = stringResource(R.string.image_editing),
+                    onClick = { onEditImage(pageIndex) }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/org/fairscan/app/ui/screens/camera/CameraScreen.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/camera/CameraScreen.kt
@@ -118,6 +118,7 @@ fun CameraScreen(
     onImageAnalyzed: (ImageProxy) -> Unit,
     onFinalizePressed: () -> Unit,
     cameraPermission: CameraPermissionState,
+    imageEditingEnabled: Boolean = false,
 ) {
     var previewView by remember { mutableStateOf<PreviewView?>(null) }
     val document by viewModel.documentUiModel.collectAsStateWithLifecycle()
@@ -210,7 +211,7 @@ fun CameraScreen(
                 Log.i("FairScan", "Pressed <Capture>")
                 cameraViewModel.onCapturePressed(it)
                 captureController.takePicture(
-                    onImageCaptured = { imageProxy -> cameraViewModel.onImageCaptured(imageProxy) }
+                    onImageCaptured = { imageProxy -> cameraViewModel.onImageCaptured(imageProxy, imageEditingEnabled) }
                 )
             }
         },

--- a/app/src/main/java/org/fairscan/app/ui/screens/camera/CameraViewModel.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/camera/CameraViewModel.kt
@@ -36,6 +36,7 @@ import org.fairscan.app.domain.PageMetadata
 import org.fairscan.app.domain.Rotation
 import org.fairscan.imageprocessing.ImageSize
 import org.fairscan.imageprocessing.Mask
+import org.fairscan.imageprocessing.Point
 import org.fairscan.imageprocessing.Quad
 import org.fairscan.imageprocessing.detectDocumentQuad
 import org.fairscan.imageprocessing.encodeJpeg
@@ -48,6 +49,7 @@ import org.opencv.imgproc.Imgproc
 
 sealed interface CameraEvent {
     data class ImageCaptured(val page: CapturedPage) : CameraEvent
+    data class ImageCapturedForEditing(val page: CapturedPage) : CameraEvent
 }
 
 class CameraViewModel(appContainer: AppContainer): ViewModel() {
@@ -135,14 +137,21 @@ class CameraViewModel(appContainer: AppContainer): ViewModel() {
         }
     }
 
-    fun onImageCaptured(imageProxy: ImageProxy?) {
+    fun onImageCaptured(imageProxy: ImageProxy?, imageEditingEnabled: Boolean = false) {
         if (imageProxy != null) {
             viewModelScope.launch {
                 try {
                     val source = imageProxy.toBitmap()
-                    val page = processCapturedImage(source, imageProxy.imageInfo.rotationDegrees)
+                    val rotationDegrees = imageProxy.imageInfo.rotationDegrees
+                    val page = processCapturedImage(source, rotationDegrees)
                     imageProxy.close()
-                    onCaptureProcessed(page)
+                    if (page == null && imageEditingEnabled) {
+                        val fallbackPage = createFullImagePage(source, rotationDegrees)
+                        _events.emit(CameraEvent.ImageCapturedForEditing(fallbackPage))
+                        _captureState.value = CaptureState.Idle
+                    } else {
+                        onCaptureProcessed(page)
+                    }
                 } catch (e: RuntimeException) {
                     logger.e("Camera", "Failed to process captured image", e)
                     onCaptureProcessed(null)
@@ -151,6 +160,27 @@ class CameraViewModel(appContainer: AppContainer): ViewModel() {
         } else {
             onCaptureProcessed(null)
         }
+    }
+
+    private suspend fun createFullImagePage(
+        source: Bitmap, rotationDegrees: Int
+    ): CapturedPage = withContext(Dispatchers.IO) {
+        val rotatedSource = if (rotationDegrees != 0) {
+            rotateBitmap(source, rotationDegrees.toFloat())
+        } else source
+        val pageJpeg = compressJpeg(rotatedSource, ExportQuality.BALANCED.jpegQuality)
+        if (rotatedSource !== source) rotatedSource.recycle()
+
+        val normalizedQuad = Quad(
+            Point(0.0, 0.0), Point(1.0, 0.0),
+            Point(1.0, 1.0), Point(0.0, 1.0)
+        )
+        val baseRotation = Rotation.fromDegrees(rotationDegrees)
+        val metadata = PageMetadata(normalizedQuad, baseRotation, isColored = true)
+        val sourceJpegDeferred = viewModelScope.async(Dispatchers.IO) {
+            compressJpeg(source, 90)
+        }
+        CapturedPage(pageJpeg, sourceJpegDeferred, metadata)
     }
 
     private suspend fun processCapturedImage(

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
@@ -20,7 +20,10 @@ import android.graphics.BitmapFactory
 import android.graphics.Matrix
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -44,6 +47,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
@@ -55,6 +59,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import org.fairscan.app.R
 import org.fairscan.app.data.ImageRepository
@@ -298,61 +303,108 @@ private fun DragQuadOverlay(
         containerSize = containerSize,
         displaySize = displaySize,
         modifier = Modifier.pointerInput(Unit) {
-            detectDragGestures(
-                onDragStart = { startPos ->
-                    val quad = state.editableQuad ?: return@detectDragGestures
-                    state.dragPosition = startPos
+                detectDragGestures(
+                    onDragStart = { startPos ->
+                        val quad = state.editableQuad ?: return@detectDragGestures
+                        state.dragPosition = startPos
 
-                    val cornerIndex = quadHandler.findTouchedCorner(
-                        startPos, quad, containerSize, displaySize
-                    )
+                        // Prefer the index stored at raw touch-down (exact touch position,
+                        // before slop). Fall back to re-detecting at the slop position only
+                        // when the raw-touch handler missed the down event.
+                        val cornerIndex = if (state.touchDownCornerIndex >= 0) {
+                            state.touchDownCornerIndex
+                        } else {
+                            quadHandler.findTouchedCorner(startPos, quad, containerSize, displaySize)
+                        }
 
-                    if (cornerIndex >= 0) {
-                        state.startCornerDrag(cornerIndex)
-                    } else {
-                        val edgeIndex = quadHandler.findTouchedEdge(
-                            startPos, quad, containerSize, displaySize
+                        if (cornerIndex >= 0) {
+                            state.startCornerDrag(cornerIndex)
+                        } else {
+                            val edgeIndex = if (state.touchDownEdgeIndex >= 0) {
+                                state.touchDownEdgeIndex
+                            } else {
+                                quadHandler.findTouchedEdge(startPos, quad, containerSize, displaySize)
+                            }
+                            if (edgeIndex >= 0) {
+                                state.startEdgeDrag(edgeIndex)
+                            }
+                        }
+                    },
+                    onDragEnd = { state.endDrag(); state.onTouchUp() },
+                    onDragCancel = { state.endDrag(); state.onTouchUp() },
+                    onDrag = { change, dragAmount ->
+                        // change.consume() is intentionally omitted: detectDragGestures
+                        // already calls it.consume() internally after this callback returns.
+                        state.dragPosition = change.position
+                        val quad = state.editableQuad ?: return@detectDragGestures
+                        val normalizedDelta = QuadCoordinateUtils.screenDeltaToNormalized(
+                            dragAmount, displaySize
                         )
-                        if (edgeIndex >= 0) {
-                            state.startEdgeDrag(edgeIndex)
+
+                        when {
+                            state.draggedCornerIndex >= 0 -> {
+                                state.updateQuad(
+                                    quadHandler.updateQuadCorner(
+                                        quad, state.draggedCornerIndex, normalizedDelta
+                                    )
+                                )
+                            }
+                            state.draggedEdgeIndex >= 0 -> {
+                                state.updateQuad(
+                                    quadHandler.updateQuadEdge(
+                                        quad, state.draggedEdgeIndex, normalizedDelta
+                                    )
+                                )
+                            }
                         }
                     }
-                },
-                onDragEnd = { state.endDrag() },
-                onDragCancel = { state.endDrag() },
-                onDrag = { change, dragAmount ->
-                    change.consume()
-                    state.dragPosition = change.position
-                    val quad = state.editableQuad ?: return@detectDragGestures
-                    val normalizedDelta = QuadCoordinateUtils.screenDeltaToNormalized(
-                        dragAmount, displaySize
-                    )
-
-                    when {
-                        state.draggedCornerIndex >= 0 -> {
-                            state.updateQuad(
-                                quadHandler.updateQuadCorner(
-                                    quad, state.draggedCornerIndex, normalizedDelta
-                                )
-                            )
+                )
+            }
+            // Second pointer-input: fires immediately on press (before touch slop)
+            // so the loupe appears as soon as the finger touches a handle.
+            .pointerInput(Unit) {
+                awaitEachGesture {
+                    val down = awaitFirstDown(requireUnconsumed = false)
+                    val quad = state.editableQuad
+                    if (quad != null) {
+                        val cIdx = quadHandler.findTouchedCorner(down.position, quad, containerSize, displaySize)
+                        val eIdx = if (cIdx < 0) quadHandler.findTouchedEdge(down.position, quad, containerSize, displaySize) else -1
+                        if (cIdx >= 0 || eIdx >= 0) {
+                            state.onTouchDown(down.position, cIdx, eIdx)
                         }
-                        state.draggedEdgeIndex >= 0 -> {
-                            state.updateQuad(
-                                quadHandler.updateQuadEdge(
-                                    quad, state.draggedEdgeIndex, normalizedDelta
-                                )
-                            )
-                        }
+                    }
+                    // For a tap (no drag): waitForUpOrCancellation() sees the UP event and
+                    // returns it, so we call onTouchUp() here.
+                    // For a drag: detectDragGestures consumes move events, causing
+                    // waitForUpOrCancellation() to return null. We do NOT call onTouchUp()
+                    // here; onDragEnd / onDragCancel above handle that instead.
+                    if (waitForUpOrCancellation() != null) {
+                        state.onTouchUp()
                     }
                 }
-            )
-        }
+            }
     )
 }
 
 @Composable
 private fun DragMagnifyingGlass(state: EditPageScreenState) {
-    if (!state.isDragging() || state.dragPosition == null || state.containerSize == null) return
+    // showLoupe becomes true immediately on touch-down and stays true for
+    // one additional second after the finger is lifted.
+    val showLoupe = remember { mutableStateOf(false) }
+    // Remember the last valid focus position so the loupe keeps rendering
+    // correctly during the 1-second fade-out (when dragged indices are reset).
+    val lastKnownFocusPosition = remember { mutableStateOf<Offset?>(null) }
+
+    LaunchedEffect(state.isTouching) {
+        if (state.isTouching) {
+            showLoupe.value = true
+        } else {
+            delay(1_000)
+            showLoupe.value = false
+        }
+    }
+
+    if (!showLoupe.value || state.dragPosition == null || state.containerSize == null) return
 
     val bmp = state.bitmap ?: return
     val containerSize = state.containerSize!!
@@ -361,10 +413,19 @@ private fun DragMagnifyingGlass(state: EditPageScreenState) {
     )
     val quad = state.editableQuad
 
+    // Resolve which corner/edge index to focus on.
+    // Priority: active drag > pre-drag touch-down > nothing (fade-out phase).
+    val activeCornerIndex = state.draggedCornerIndex.takeIf { it >= 0 }
+        ?: state.touchDownCornerIndex.takeIf { it >= 0 }
+    val activeEdgeIndex = if (activeCornerIndex == null) {
+        state.draggedEdgeIndex.takeIf { it >= 0 }
+            ?: state.touchDownEdgeIndex.takeIf { it >= 0 }
+    } else null
+
     val focusPosition = if (quad != null) {
         when {
-            state.draggedCornerIndex >= 0 -> {
-                val corner = when (state.draggedCornerIndex) {
+            activeCornerIndex != null -> {
+                val corner = when (activeCornerIndex) {
                     0 -> quad.topLeft
                     1 -> quad.topRight
                     2 -> quad.bottomRight
@@ -375,8 +436,8 @@ private fun DragMagnifyingGlass(state: EditPageScreenState) {
                     QuadCoordinateUtils.normalizedToScreen(it, containerSize, displaySize)
                 }
             }
-            state.draggedEdgeIndex >= 0 -> {
-                val (p1, p2) = when (state.draggedEdgeIndex) {
+            activeEdgeIndex != null -> {
+                val (p1, p2) = when (activeEdgeIndex) {
                     0 -> quad.topLeft to quad.topRight
                     1 -> quad.topRight to quad.bottomRight
                     2 -> quad.bottomRight to quad.bottomLeft
@@ -395,15 +456,19 @@ private fun DragMagnifyingGlass(state: EditPageScreenState) {
         }
     } else null
 
-    if (focusPosition != null) {
-        MagnifyingGlass(
-            bitmap = bmp,
-            fingerPosition = state.dragPosition!!,
-            focusPosition = focusPosition,
-            containerSize = containerSize,
-            displaySize = displaySize,
-        )
-    }
+    // Keep the last known focus position so it's still valid after endDrag() resets the indices.
+    if (focusPosition != null) lastKnownFocusPosition.value = focusPosition
+    // On the very first touch the drag indices are not set yet and lastKnownFocusPosition
+    // has never been populated, so fall back to dragPosition (the finger is on the handle).
+    val effectiveFocusPosition = focusPosition ?: lastKnownFocusPosition.value ?: state.dragPosition ?: return
+
+    MagnifyingGlass(
+        bitmap = bmp,
+        fingerPosition = state.dragPosition!!,
+        focusPosition = effectiveFocusPosition,
+        containerSize = containerSize,
+        displaySize = displaySize,
+    )
 }
 
 @Composable

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
@@ -87,7 +87,7 @@ fun EditPageScreen(
     pageId: String,
     imageRepository: ImageRepository,
     navigation: Navigation,
-    onUpdatePageQuad: (String, Quad) -> Unit,
+    onUpdatePageQuad: (String, Quad, onComplete: () -> Unit) -> Unit,
 ) {
     val showDiscardChangesDialog = rememberSaveable { mutableStateOf(false) }
     val state = remember { EditPageScreenState() }
@@ -220,7 +220,6 @@ fun EditPageScreen(
                     } else {
                         navigation.back()
                     }
-                    navigation.back()
                 }
             )
         }
@@ -502,7 +501,7 @@ fun EditPageScreenPreview() {
             pageId = "preview-page-id",
             imageRepository = dummyImageRepo,
             navigation = dummyNavigation(),
-            onUpdatePageQuad = { _, _ -> }
+            onUpdatePageQuad = { _, _, onComplete -> onComplete() }
         )
     }
 }

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
@@ -194,11 +194,20 @@ fun EditPageScreen(
                 onRedo = { state.redo() },
                 onConfirm = {
                     state.editableQuad?.let { quad ->
-                        // Reverse the rotation to get back to original source image coordinates
-                        val rotateIterations = (4 - baseRotation.value.degrees / 90) % 4
-                        val originalQuad = quad.rotate90(rotateIterations, ImageSize(1, 1))
-                        onUpdatePageQuad(pageId, originalQuad)
-                        state.setInitialQuad(quad)
+                        if (state.hasUnsavedChanges()) {
+                            // Reverse the rotation to get back to original source image coordinates
+                            val rotateIterations = (4 - baseRotation.value.degrees / 90) % 4
+                            val originalQuad = quad.rotate90(rotateIterations, ImageSize(1, 1))
+                            // Cycle the quad corners so that the perspective warp in
+                            // extractDocument produces output already rotated by
+                            // baseRotation, compensating for the fact that updatePageQuad
+                            // only applies manualRotationDegrees.
+                            val cycledQuad = cycleQuadCorners(
+                                originalQuad, baseRotation.value.degrees / 90
+                            )
+                            onUpdatePageQuad(pageId, cycledQuad)
+                            state.setInitialQuad(quad)
+                        }
                     }
                     navigation.back()
                 }
@@ -408,5 +417,22 @@ fun EditPageScreenPreview() {
             navigation = dummyNavigation(),
             onUpdatePageQuad = { _, _ -> }
         )
+    }
+}
+
+/**
+ * Cycles the corner labels of a [Quad] so that a perspective warp using the
+ * returned quad produces output that is already rotated by [iterations] × 90°
+ * clockwise, without moving any source-image point.
+ *
+ * This compensates for [ImageRepository.updatePageQuad] passing only
+ * `manualRotationDegrees` (not `baseRotationDegrees`) to `extractDocument`.
+ */
+internal fun cycleQuadCorners(quad: Quad, iterations: Int): Quad {
+    return when ((iterations % 4 + 4) % 4) {
+        1 -> Quad(quad.bottomLeft, quad.topLeft, quad.topRight, quad.bottomRight)
+        2 -> Quad(quad.bottomRight, quad.bottomLeft, quad.topLeft, quad.topRight)
+        3 -> Quad(quad.topRight, quad.bottomRight, quad.bottomLeft, quad.topLeft)
+        else -> quad
     }
 }

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
@@ -16,20 +16,30 @@ package org.fairscan.app.ui.screens.edit
 
 import android.content.res.Configuration
 import android.graphics.BitmapFactory
+import android.graphics.Matrix
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Redo
+import androidx.compose.material.icons.automirrored.filled.Undo
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
@@ -38,16 +48,26 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.fairscan.app.R
 import org.fairscan.app.data.ImageRepository
 import org.fairscan.app.data.ImageTransformations
+import org.fairscan.app.domain.ExportQuality
+import org.fairscan.app.domain.Rotation
 import org.fairscan.app.ui.Navigation
 import org.fairscan.app.ui.components.AppOverflowMenu
 import org.fairscan.app.ui.components.BackButton
+import org.fairscan.app.ui.components.ConfirmationDialog
+import org.fairscan.app.ui.components.SecondaryActionButton
 import org.fairscan.app.ui.dummyNavigation
 import org.fairscan.app.ui.theme.FairScanTheme
+import org.fairscan.imageprocessing.ImageSize
+import org.fairscan.imageprocessing.Point
+import org.fairscan.imageprocessing.Quad
 import java.io.File
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -56,11 +76,21 @@ fun EditPageScreen(
     pageId: String,
     imageRepository: ImageRepository,
     navigation: Navigation,
+    onUpdatePageQuad: (String, Quad) -> Unit,
 ) {
-    BackHandler { navigation.back() }
-
+    val showDiscardChangesDialog = rememberSaveable { mutableStateOf(false) }
     val state = remember { EditPageScreenState() }
     val quadHandler = remember { QuadEditingHandler() }
+
+    val handleBack = {
+        if (state.hasUnsavedChanges()) {
+            showDiscardChangesDialog.value = true
+        } else {
+            navigation.back()
+        }
+    }
+
+    BackHandler { handleBack() }
 
     val isPreview = LocalInspectionMode.current
     if (isPreview) {
@@ -68,11 +98,16 @@ fun EditPageScreen(
             BitmapFactory.decodeStream(input)
         }
         state.bitmap = dummyImage
+        state.setInitialQuad(Quad(Point(.1, .1), Point(.9, .1), Point(.9, .9), Point(.1, .9)))
     }
+
+    val baseRotation = remember { mutableStateOf(Rotation.R0) }
 
     LaunchedEffect(pageId) {
         val metadata = imageRepository.getPageMetadata(pageId)
         val rotation = metadata?.baseRotation ?: Rotation.R0
+        baseRotation.value = rotation
+
         val bitmap = withContext(Dispatchers.IO) {
             val sourceJpegBytes = imageRepository.sourceJpegBytes(pageId)
             if (sourceJpegBytes != null) {
@@ -93,7 +128,14 @@ fun EditPageScreen(
             } else null
         }
         state.bitmap = bitmap  // assigned on the main thread after withContext returns
-        state.editableQuad = imageRepository.getPageMetadata(pageId)?.normalizedQuad
+        if (metadata?.normalizedQuad != null) {
+            // Rotate the quad to match the rotated bitmap display
+            val rotatedQuad = metadata.normalizedQuad.rotate90(
+                rotation.degrees / 90,
+                ImageSize(1, 1)
+            )
+            state.setInitialQuad(rotatedQuad)
+        }
     }
 
     Scaffold { innerPadding ->
@@ -186,7 +228,7 @@ fun EditPageScreen(
             }
 
             BackButton(
-                navigation.back,
+                onClick = handleBack,
                 modifier = Modifier
                     .align(Alignment.TopStart)
                     .windowInsetsPadding(WindowInsets.safeDrawing)
@@ -198,7 +240,74 @@ fun EditPageScreen(
                     .align(Alignment.TopEnd)
                     .windowInsetsPadding(WindowInsets.safeDrawing)
             )
+
+            ActionButtons(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(16.dp)
+                    .windowInsetsPadding(WindowInsets.safeDrawing),
+                canUndo = state.history.canUndo,
+                canRedo = state.history.canRedo,
+                onUndo = { state.undo() },
+                onRedo = { state.redo() },
+                onConfirm = {
+                    state.editableQuad?.let { quad ->
+                        // Reverse the rotation to get back to original source image coordinates
+                        val rotateIterations = (4 - baseRotation.value.degrees / 90) % 4
+                        val originalQuad = quad.rotate90(rotateIterations, ImageSize(1, 1))
+                        onUpdatePageQuad(pageId, originalQuad)
+                        state.setInitialQuad(quad)
+                    }
+                    navigation.back()
+                }
+            )
         }
+    }
+
+    if (showDiscardChangesDialog.value) {
+        ConfirmationDialog(
+            title = stringResource(R.string.discard_changes),
+            message = stringResource(R.string.discard_changes_warning),
+            showDialog = showDiscardChangesDialog
+        ) {
+            state.revertToInitial()
+            navigation.back()
+        }
+    }
+}
+
+@Composable
+private fun ActionButtons(
+    modifier: Modifier,
+    canUndo: Boolean,
+    canRedo: Boolean,
+    onUndo: () -> Unit,
+    onRedo: () -> Unit,
+    onConfirm: () -> Unit
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        SecondaryActionButton(
+            icon = Icons.AutoMirrored.Filled.Undo,
+            contentDescription = "Undo",
+            onClick = onUndo,
+            enabled = canUndo
+        )
+
+        SecondaryActionButton(
+            icon = Icons.AutoMirrored.Filled.Redo,
+            contentDescription = "Redo",
+            onClick = onRedo,
+            enabled = canRedo
+        )
+
+        SecondaryActionButton(
+            icon = Icons.Filled.Check,
+            contentDescription = "Confirm",
+            onClick = onConfirm
+        )
     }
 }
 
@@ -213,6 +322,14 @@ fun EditPageScreenPreview() {
         val dummyTransformations = object : ImageTransformations {
             override fun rotate(inputFile: File, outputFile: File, rotationDegrees: Int, jpegQuality: Int) = Unit
             override fun resize(inputFile: File, outputFile: File, maxSize: Int) = Unit
+            override fun extractDocument(
+                inputFile: File,
+                outputFile: File,
+                normalizedQuad: Quad,
+                rotationDegrees: Int,
+                isColored: Boolean,
+                quality: ExportQuality
+            ) = Unit
         }
 
         // Use a temporary directory for the repository in preview.
@@ -223,6 +340,7 @@ fun EditPageScreenPreview() {
             pageId = "preview-page-id",
             imageRepository = dummyImageRepo,
             navigation = dummyNavigation(),
+            onUpdatePageQuad = { _, _ -> }
         )
     }
 }

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2026 Philipp Hasper
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.fairscan.app.ui.screens.edit
+
+import android.content.res.Configuration
+import android.graphics.BitmapFactory
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.tooling.preview.Preview
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.fairscan.app.data.ImageRepository
+import org.fairscan.app.data.ImageTransformations
+import org.fairscan.app.ui.Navigation
+import org.fairscan.app.ui.components.AppOverflowMenu
+import org.fairscan.app.ui.components.BackButton
+import org.fairscan.app.ui.dummyNavigation
+import org.fairscan.app.ui.theme.FairScanTheme
+import java.io.File
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EditPageScreen(
+    pageId: String,
+    imageRepository: ImageRepository,
+    navigation: Navigation,
+) {
+    BackHandler { navigation.back() }
+
+    val state = remember { EditPageScreenState() }
+    val quadHandler = remember { QuadEditingHandler() }
+
+    val isPreview = LocalInspectionMode.current
+    if (isPreview) {
+        val dummyImage = LocalContext.current.assets.open("gallica.bnf.fr-bpt6k5530456s-1.jpg").use { input ->
+            BitmapFactory.decodeStream(input)
+        }
+        state.bitmap = dummyImage
+    }
+
+    LaunchedEffect(pageId) {
+        val metadata = imageRepository.getPageMetadata(pageId)
+        val rotation = metadata?.baseRotation ?: Rotation.R0
+        val bitmap = withContext(Dispatchers.IO) {
+            val sourceJpegBytes = imageRepository.sourceJpegBytes(pageId)
+            if (sourceJpegBytes != null) {
+                val original = BitmapFactory.decodeByteArray(sourceJpegBytes, 0, sourceJpegBytes.size)
+                if (original != null && rotation != Rotation.R0) {
+                    // Adjust the displayed bitmap's rotation to what is in the metadata
+                    val matrix = Matrix().apply { postRotate(rotation.degrees.toFloat()) }
+                    val rotated = android.graphics.Bitmap.createBitmap(
+                        original, 0, 0, original.width, original.height, matrix, true
+                    )
+                    if (rotated !== original) {
+                        original.recycle()
+                    }
+                    rotated
+                } else {
+                    original
+                }
+            } else null
+        }
+        state.bitmap = bitmap  // assigned on the main thread after withContext returns
+        state.editableQuad = imageRepository.getPageMetadata(pageId)?.normalizedQuad
+    }
+
+    Scaffold { innerPadding ->
+        Box(modifier = Modifier
+            .fillMaxSize()
+            .padding(innerPadding)
+            .windowInsetsPadding(WindowInsets.statusBars)
+        ) {
+            state.bitmap?.let { bmp ->
+                val imageBitmap = remember(bmp) { bmp.asImageBitmap() }
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .align(Alignment.Center),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Image(
+                        bitmap = imageBitmap,
+                        contentDescription = "Image to edit",
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .onGloballyPositioned { coordinates ->
+                                state.containerSize = coordinates.size
+                            },
+                        contentScale = ContentScale.Fit,
+                    )
+
+                    if (state.editableQuad != null && state.containerSize != null) {
+                        val containerSize = state.containerSize!!
+                        val displaySize = QuadCoordinateUtils.calculateDisplaySize(
+                            bmp.width, bmp.height, containerSize
+                        )
+
+                        QuadOverlay(
+                            quad = state.editableQuad!!,
+                            containerSize = containerSize,
+                            displaySize = displaySize,
+                            modifier = Modifier.pointerInput(Unit) {
+                                detectDragGestures(
+                                    onDragStart = { startPos ->
+                                        val quad = state.editableQuad ?: return@detectDragGestures
+
+                                        val cornerIndex = quadHandler.findTouchedCorner(
+                                            startPos, quad, containerSize, displaySize
+                                        )
+
+                                        if (cornerIndex >= 0) {
+                                            state.startCornerDrag(cornerIndex)
+                                        } else {
+                                            val edgeIndex = quadHandler.findTouchedEdge(
+                                                startPos, quad, containerSize, displaySize
+                                            )
+                                            if (edgeIndex >= 0) {
+                                                state.startEdgeDrag(edgeIndex)
+                                            }
+                                        }
+                                    },
+                                    onDragEnd = { state.endDrag() },
+                                    onDragCancel = { state.endDrag() },
+                                    onDrag = { change, dragAmount ->
+                                        change.consume()
+                                        val quad = state.editableQuad ?: return@detectDragGestures
+                                        val normalizedDelta = QuadCoordinateUtils.screenDeltaToNormalized(
+                                            dragAmount, displaySize
+                                        )
+
+                                        when {
+                                            state.draggedCornerIndex >= 0 -> {
+                                                state.updateQuad(
+                                                    quadHandler.updateQuadCorner(
+                                                        quad, state.draggedCornerIndex, normalizedDelta
+                                                    )
+                                                )
+                                            }
+                                            state.draggedEdgeIndex >= 0 -> {
+                                                state.updateQuad(
+                                                    quadHandler.updateQuadEdge(
+                                                        quad, state.draggedEdgeIndex, normalizedDelta
+                                                    )
+                                                )
+                                            }
+                                        }
+                                    }
+                                )
+                            }
+                        )
+                    }
+                }
+            }
+
+            BackButton(
+                navigation.back,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .windowInsetsPadding(WindowInsets.safeDrawing)
+            )
+
+            AppOverflowMenu(
+                navigation,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .windowInsetsPadding(WindowInsets.safeDrawing)
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+@Preview(name = "Dark Mode", uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true)
+@Preview(name = "Landscape", showBackground = true, widthDp = 640, heightDp = 320)
+fun EditPageScreenPreview() {
+    FairScanTheme {
+
+        // Minimal no-op ImageTransformations implementation used only for preview.
+        val dummyTransformations = object : ImageTransformations {
+            override fun rotate(inputFile: File, outputFile: File, rotationDegrees: Int, jpegQuality: Int) = Unit
+            override fun resize(inputFile: File, outputFile: File, maxSize: Int) = Unit
+        }
+
+        // Use a temporary directory for the repository in preview.
+        val tempDir = File(System.getProperty("java.io.tmpdir") ?: "/tmp")
+        val dummyImageRepo = ImageRepository(tempDir, dummyTransformations, 128)
+
+        EditPageScreen(
+            pageId = "preview-page-id",
+            imageRepository = dummyImageRepo,
+            navigation = dummyNavigation(),
+        )
+    }
+}

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
@@ -101,12 +101,14 @@ fun EditPageScreen(
         state.setInitialQuad(Quad(Point(.1, .1), Point(.9, .1), Point(.9, .9), Point(.1, .9)))
     }
 
-    val baseRotation = remember { mutableStateOf(Rotation.R0) }
+    val totalRotation = remember { mutableStateOf(Rotation.R0) }
 
     LaunchedEffect(pageId) {
         val metadata = imageRepository.getPageMetadata(pageId)
-        val rotation = metadata?.baseRotation ?: Rotation.R0
-        baseRotation.value = rotation
+        val baseRotation = metadata?.baseRotation ?: Rotation.R0
+        val manualRotation = imageRepository.getManualRotation(pageId)
+        val rotation = baseRotation.add(manualRotation)
+        totalRotation.value = rotation
 
         val bitmap = withContext(Dispatchers.IO) {
             val sourceJpegBytes = imageRepository.sourceJpegBytes(pageId)
@@ -193,21 +195,17 @@ fun EditPageScreen(
                 onUndo = { state.undo() },
                 onRedo = { state.redo() },
                 onConfirm = {
-                    state.editableQuad?.let { quad ->
-                        if (state.hasUnsavedChanges()) {
-                            // Reverse the rotation to get back to original source image coordinates
-                            val rotateIterations = (4 - baseRotation.value.degrees / 90) % 4
-                            val originalQuad = quad.rotate90(rotateIterations, ImageSize(1, 1))
-                            // Cycle the quad corners so that the perspective warp in
-                            // extractDocument produces output already rotated by
-                            // baseRotation, compensating for the fact that updatePageQuad
-                            // only applies manualRotationDegrees.
-                            val cycledQuad = cycleQuadCorners(
-                                originalQuad, baseRotation.value.degrees / 90
-                            )
-                            onUpdatePageQuad(pageId, cycledQuad)
-                            state.setInitialQuad(quad)
+                    val quad = state.editableQuad
+                    if (quad != null) {
+                        // Reverse the total rotation to get back to original source image coordinates
+                        val rotateIterations = (4 - totalRotation.value.degrees / 90) % 4
+                        val originalQuad = quad.rotate90(rotateIterations, ImageSize(1, 1))
+                        onUpdatePageQuad(pageId, originalQuad) {
+                            navigation.back()
                         }
+                        state.setInitialQuad(quad)
+                    } else {
+                        navigation.back()
                     }
                     navigation.back()
                 }
@@ -417,22 +415,5 @@ fun EditPageScreenPreview() {
             navigation = dummyNavigation(),
             onUpdatePageQuad = { _, _ -> }
         )
-    }
-}
-
-/**
- * Cycles the corner labels of a [Quad] so that a perspective warp using the
- * returned quad produces output that is already rotated by [iterations] × 90°
- * clockwise, without moving any source-image point.
- *
- * This compensates for [ImageRepository.updatePageQuad] passing only
- * `manualRotationDegrees` (not `baseRotationDegrees`) to `extractDocument`.
- */
-internal fun cycleQuadCorners(quad: Quad, iterations: Int): Quad {
-    return when ((iterations % 4 + 4) % 4) {
-        1 -> Quad(quad.bottomLeft, quad.topLeft, quad.topRight, quad.bottomRight)
-        2 -> Quad(quad.bottomRight, quad.bottomLeft, quad.topLeft, quad.topRight)
-        3 -> Quad(quad.topRight, quad.bottomRight, quad.bottomLeft, quad.topLeft)
-        else -> quad
     }
 }

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
@@ -468,6 +468,7 @@ private fun DragMagnifyingGlass(state: EditPageScreenState) {
         focusPosition = effectiveFocusPosition,
         containerSize = containerSize,
         displaySize = displaySize,
+        quad = state.editableQuad,
     )
 }
 

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
@@ -164,66 +164,7 @@ fun EditPageScreen(
                         contentScale = ContentScale.Fit,
                     )
 
-                    if (state.editableQuad != null && state.containerSize != null) {
-                        val containerSize = state.containerSize!!
-                        val displaySize = QuadCoordinateUtils.calculateDisplaySize(
-                            bmp.width, bmp.height, containerSize
-                        )
-
-                        QuadOverlay(
-                            quad = state.editableQuad!!,
-                            containerSize = containerSize,
-                            displaySize = displaySize,
-                            modifier = Modifier.pointerInput(Unit) {
-                                detectDragGestures(
-                                    onDragStart = { startPos ->
-                                        val quad = state.editableQuad ?: return@detectDragGestures
-
-                                        val cornerIndex = quadHandler.findTouchedCorner(
-                                            startPos, quad, containerSize, displaySize
-                                        )
-
-                                        if (cornerIndex >= 0) {
-                                            state.startCornerDrag(cornerIndex)
-                                        } else {
-                                            val edgeIndex = quadHandler.findTouchedEdge(
-                                                startPos, quad, containerSize, displaySize
-                                            )
-                                            if (edgeIndex >= 0) {
-                                                state.startEdgeDrag(edgeIndex)
-                                            }
-                                        }
-                                    },
-                                    onDragEnd = { state.endDrag() },
-                                    onDragCancel = { state.endDrag() },
-                                    onDrag = { change, dragAmount ->
-                                        change.consume()
-                                        val quad = state.editableQuad ?: return@detectDragGestures
-                                        val normalizedDelta = QuadCoordinateUtils.screenDeltaToNormalized(
-                                            dragAmount, displaySize
-                                        )
-
-                                        when {
-                                            state.draggedCornerIndex >= 0 -> {
-                                                state.updateQuad(
-                                                    quadHandler.updateQuadCorner(
-                                                        quad, state.draggedCornerIndex, normalizedDelta
-                                                    )
-                                                )
-                                            }
-                                            state.draggedEdgeIndex >= 0 -> {
-                                                state.updateQuad(
-                                                    quadHandler.updateQuadEdge(
-                                                        quad, state.draggedEdgeIndex, normalizedDelta
-                                                    )
-                                                )
-                                            }
-                                        }
-                                    }
-                                )
-                            }
-                        )
-                    }
+                    DragQuadOverlay(state, quadHandler, bmp)
                 }
             }
 
@@ -233,13 +174,14 @@ fun EditPageScreen(
                     .align(Alignment.TopStart)
                     .windowInsetsPadding(WindowInsets.safeDrawing)
             )
-
             AppOverflowMenu(
                 navigation,
                 modifier = Modifier
                     .align(Alignment.TopEnd)
                     .windowInsetsPadding(WindowInsets.safeDrawing)
             )
+
+            DragMagnifyingGlass(state)
 
             ActionButtons(
                 modifier = Modifier
@@ -307,6 +249,130 @@ private fun ActionButtons(
             icon = Icons.Filled.Check,
             contentDescription = "Confirm",
             onClick = onConfirm
+        )
+    }
+}
+
+@Composable
+private fun DragQuadOverlay(
+    state: EditPageScreenState,
+    quadHandler: QuadEditingHandler,
+    bmp: android.graphics.Bitmap
+) {
+    if (state.editableQuad == null || state.containerSize == null) return
+
+    val containerSize = state.containerSize!!
+    val displaySize = QuadCoordinateUtils.calculateDisplaySize(bmp.width, bmp.height, containerSize)
+
+    QuadOverlay(
+        quad = state.editableQuad!!,
+        containerSize = containerSize,
+        displaySize = displaySize,
+        modifier = Modifier.pointerInput(Unit) {
+            detectDragGestures(
+                onDragStart = { startPos ->
+                    val quad = state.editableQuad ?: return@detectDragGestures
+                    state.dragPosition = startPos
+
+                    val cornerIndex = quadHandler.findTouchedCorner(
+                        startPos, quad, containerSize, displaySize
+                    )
+
+                    if (cornerIndex >= 0) {
+                        state.startCornerDrag(cornerIndex)
+                    } else {
+                        val edgeIndex = quadHandler.findTouchedEdge(
+                            startPos, quad, containerSize, displaySize
+                        )
+                        if (edgeIndex >= 0) {
+                            state.startEdgeDrag(edgeIndex)
+                        }
+                    }
+                },
+                onDragEnd = { state.endDrag() },
+                onDragCancel = { state.endDrag() },
+                onDrag = { change, dragAmount ->
+                    change.consume()
+                    state.dragPosition = change.position
+                    val quad = state.editableQuad ?: return@detectDragGestures
+                    val normalizedDelta = QuadCoordinateUtils.screenDeltaToNormalized(
+                        dragAmount, displaySize
+                    )
+
+                    when {
+                        state.draggedCornerIndex >= 0 -> {
+                            state.updateQuad(
+                                quadHandler.updateQuadCorner(
+                                    quad, state.draggedCornerIndex, normalizedDelta
+                                )
+                            )
+                        }
+                        state.draggedEdgeIndex >= 0 -> {
+                            state.updateQuad(
+                                quadHandler.updateQuadEdge(
+                                    quad, state.draggedEdgeIndex, normalizedDelta
+                                )
+                            )
+                        }
+                    }
+                }
+            )
+        }
+    )
+}
+
+@Composable
+private fun DragMagnifyingGlass(state: EditPageScreenState) {
+    if (!state.isDragging() || state.dragPosition == null || state.containerSize == null) return
+
+    val bmp = state.bitmap ?: return
+    val containerSize = state.containerSize!!
+    val displaySize = QuadCoordinateUtils.calculateDisplaySize(
+        bmp.width, bmp.height, containerSize
+    )
+    val quad = state.editableQuad
+
+    val focusPosition = if (quad != null) {
+        when {
+            state.draggedCornerIndex >= 0 -> {
+                val corner = when (state.draggedCornerIndex) {
+                    0 -> quad.topLeft
+                    1 -> quad.topRight
+                    2 -> quad.bottomRight
+                    3 -> quad.bottomLeft
+                    else -> null
+                }
+                corner?.let {
+                    QuadCoordinateUtils.normalizedToScreen(it, containerSize, displaySize)
+                }
+            }
+            state.draggedEdgeIndex >= 0 -> {
+                val (p1, p2) = when (state.draggedEdgeIndex) {
+                    0 -> quad.topLeft to quad.topRight
+                    1 -> quad.topRight to quad.bottomRight
+                    2 -> quad.bottomRight to quad.bottomLeft
+                    3 -> quad.bottomLeft to quad.topLeft
+                    else -> null to null
+                }
+                if (p1 != null && p2 != null) {
+                    val mid = Point(
+                        (p1.x + p2.x) / 2.0,
+                        (p1.y + p2.y) / 2.0
+                    )
+                    QuadCoordinateUtils.normalizedToScreen(mid, containerSize, displaySize)
+                } else null
+            }
+            else -> null
+        }
+    } else null
+
+    if (focusPosition != null) {
+        MagnifyingGlass(
+            bitmap = bmp,
+            fingerPosition = state.dragPosition!!,
+            focusPosition = focusPosition,
+            containerSize = containerSize,
+            displaySize = displaySize,
         )
     }
 }

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
@@ -38,8 +38,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Redo
 import androidx.compose.material.icons.automirrored.filled.Undo
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
@@ -88,6 +92,7 @@ fun EditPageScreen(
     imageRepository: ImageRepository,
     navigation: Navigation,
     onUpdatePageQuad: (String, Quad, onComplete: () -> Unit) -> Unit,
+    onReportProblem: () -> Unit = {},
 ) {
     val showDiscardChangesDialog = rememberSaveable { mutableStateOf(false) }
     val state = remember { EditPageScreenState() }
@@ -192,7 +197,17 @@ fun EditPageScreen(
                 navigation,
                 modifier = Modifier
                     .align(Alignment.TopEnd)
-                    .windowInsetsPadding(WindowInsets.safeDrawing)
+                    .windowInsetsPadding(WindowInsets.safeDrawing),
+                extraItems = { onDismiss ->
+                    DropdownMenuItem(
+                        leadingIcon = { Icon(Icons.Default.Email, contentDescription = null) },
+                        text = { Text(stringResource(R.string.report)) },
+                        onClick = {
+                            onDismiss()
+                            onReportProblem()
+                        }
+                    )
+                }
             )
 
             DragMagnifyingGlass(state)

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreen.kt
@@ -14,6 +14,7 @@
  */
 package org.fairscan.app.ui.screens.edit
 
+import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.graphics.BitmapFactory
 import android.graphics.Matrix
@@ -22,6 +23,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -46,6 +48,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.stringResource
@@ -62,7 +65,9 @@ import org.fairscan.app.ui.Navigation
 import org.fairscan.app.ui.components.AppOverflowMenu
 import org.fairscan.app.ui.components.BackButton
 import org.fairscan.app.ui.components.ConfirmationDialog
+import org.fairscan.app.ui.components.MainActionButton
 import org.fairscan.app.ui.components.SecondaryActionButton
+import org.fairscan.app.ui.components.isLandscape
 import org.fairscan.app.ui.dummyNavigation
 import org.fairscan.app.ui.theme.FairScanTheme
 import org.fairscan.imageprocessing.ImageSize
@@ -70,6 +75,7 @@ import org.fairscan.imageprocessing.Point
 import org.fairscan.imageprocessing.Quad
 import java.io.File
 
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EditPageScreen(
@@ -140,10 +146,11 @@ fun EditPageScreen(
         }
     }
 
-    Scaffold { innerPadding ->
+    val isLandscape = isLandscape(LocalConfiguration.current)
+
+    Scaffold { _ ->
         Box(modifier = Modifier
             .fillMaxSize()
-            .padding(innerPadding)
             .windowInsetsPadding(WindowInsets.statusBars)
         ) {
             state.bitmap?.let { bmp ->
@@ -187,9 +194,10 @@ fun EditPageScreen(
 
             ActionButtons(
                 modifier = Modifier
-                    .align(Alignment.BottomCenter)
+                    .align(if (isLandscape) Alignment.CenterEnd else Alignment.BottomCenter)
                     .padding(16.dp)
                     .windowInsetsPadding(WindowInsets.safeDrawing),
+                isLandscape = isLandscape,
                 canUndo = state.history.canUndo,
                 canRedo = state.history.canRedo,
                 onUndo = { state.undo() },
@@ -228,35 +236,49 @@ fun EditPageScreen(
 @Composable
 private fun ActionButtons(
     modifier: Modifier,
+    isLandscape: Boolean,
     canUndo: Boolean,
     canRedo: Boolean,
     onUndo: () -> Unit,
     onRedo: () -> Unit,
     onConfirm: () -> Unit
 ) {
-    Row(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        SecondaryActionButton(
-            icon = Icons.AutoMirrored.Filled.Undo,
-            contentDescription = "Undo",
-            onClick = onUndo,
-            enabled = canUndo
-        )
+    val undo: @Composable () -> Unit = {
+        SecondaryActionButton(Icons.AutoMirrored.Filled.Undo,
+            stringResource(R.string.undo),
+            onUndo,
+            enabled = canUndo)
+    }
+    val redo: @Composable () -> Unit = {
+        SecondaryActionButton(Icons.AutoMirrored.Filled.Redo,
+            stringResource(R.string.redo),
+            onRedo,
+            enabled = canRedo)
+    }
+    val confirm: @Composable () -> Unit = {
+        MainActionButton(onConfirm,
+            stringResource(R.string.confirm),
+            Icons.Filled.Check,
+            iconDescription = stringResource(R.string.confirm))
+    }
 
-        SecondaryActionButton(
-            icon = Icons.AutoMirrored.Filled.Redo,
-            contentDescription = "Redo",
-            onClick = onRedo,
-            enabled = canRedo
-        )
-
-        SecondaryActionButton(
-            icon = Icons.Filled.Check,
-            contentDescription = "Confirm",
-            onClick = onConfirm
-        )
+    if (isLandscape) {
+        Column(
+            modifier = modifier,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) { undo(); redo() }
+            confirm()
+        }
+    } else {
+        Row(
+            modifier = modifier,
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            undo(); redo(); confirm()
+        }
     }
 }
 
@@ -385,9 +407,10 @@ private fun DragMagnifyingGlass(state: EditPageScreenState) {
 }
 
 @Composable
-@Preview
-@Preview(name = "Dark Mode", uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true)
+@Preview(showSystemUi = true)
+@Preview(name = "Dark Mode", uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true, showSystemUi = true)
 @Preview(name = "Landscape", showBackground = true, widthDp = 640, heightDp = 320)
+@Preview(name = "RTL", locale = "ar", showSystemUi = true)
 fun EditPageScreenPreview() {
     FairScanTheme {
 

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreenState.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreenState.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.IntSize
 import org.fairscan.imageprocessing.Quad
 
@@ -27,6 +28,7 @@ class EditPageScreenState {
     var editableQuad by mutableStateOf<Quad?>(null)
     var draggedCornerIndex by mutableIntStateOf(-1)
     var draggedEdgeIndex by mutableIntStateOf(-1)
+    var dragPosition by mutableStateOf<Offset?>(null)
 
     val history = QuadEditingHistory()
     private var quadBeforeDrag: Quad? = null
@@ -60,6 +62,7 @@ class EditPageScreenState {
         quadBeforeDrag = null
         draggedCornerIndex = -1
         draggedEdgeIndex = -1
+        dragPosition = null
     }
 
     fun undo() {

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreenState.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreenState.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Philipp Hasper
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.fairscan.app.ui.screens.edit
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.unit.IntSize
+import org.fairscan.imageprocessing.Quad
+
+class EditPageScreenState {
+    var bitmap by mutableStateOf<android.graphics.Bitmap?>(null)
+    var containerSize by mutableStateOf<IntSize?>(null)
+    var editableQuad by mutableStateOf<Quad?>(null)
+    var draggedCornerIndex by mutableIntStateOf(-1)
+    var draggedEdgeIndex by mutableIntStateOf(-1)
+
+    fun updateQuad(newQuad: Quad) {
+        editableQuad = newQuad
+    }
+
+    fun startCornerDrag(cornerIndex: Int) {
+        draggedCornerIndex = cornerIndex
+        draggedEdgeIndex = -1
+    }
+
+    fun startEdgeDrag(edgeIndex: Int) {
+        draggedEdgeIndex = edgeIndex
+        draggedCornerIndex = -1
+    }
+
+    fun endDrag() {
+        draggedCornerIndex = -1
+        draggedEdgeIndex = -1
+    }
+
+    fun isDragging(): Boolean = draggedCornerIndex >= 0 || draggedEdgeIndex >= 0
+}

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreenState.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreenState.kt
@@ -28,24 +28,69 @@ class EditPageScreenState {
     var draggedCornerIndex by mutableIntStateOf(-1)
     var draggedEdgeIndex by mutableIntStateOf(-1)
 
+    val history = QuadEditingHistory()
+    private var quadBeforeDrag: Quad? = null
+    private var initialQuad: Quad? = null
+
     fun updateQuad(newQuad: Quad) {
         editableQuad = newQuad
     }
 
     fun startCornerDrag(cornerIndex: Int) {
+        quadBeforeDrag = editableQuad
         draggedCornerIndex = cornerIndex
         draggedEdgeIndex = -1
     }
 
     fun startEdgeDrag(edgeIndex: Int) {
+        quadBeforeDrag = editableQuad
         draggedEdgeIndex = edgeIndex
         draggedCornerIndex = -1
     }
 
     fun endDrag() {
+        // Push state to history when drag ends (if quad changed)
+        quadBeforeDrag?.let { before ->
+            editableQuad?.let { after ->
+                if (before != after) {
+                    history.pushState(before)
+                }
+            }
+        }
+        quadBeforeDrag = null
         draggedCornerIndex = -1
         draggedEdgeIndex = -1
     }
 
+    fun undo() {
+        editableQuad?.let { current ->
+            history.undo(current)?.let { previous ->
+                editableQuad = previous
+            }
+        }
+    }
+
+    fun redo() {
+        editableQuad?.let { current ->
+            history.redo(current)?.let { next ->
+                editableQuad = next
+            }
+        }
+    }
+
     fun isDragging(): Boolean = draggedCornerIndex >= 0 || draggedEdgeIndex >= 0
+
+    fun setInitialQuad(quad: Quad) {
+        initialQuad = quad
+        editableQuad = quad
+    }
+
+    fun hasUnsavedChanges(): Boolean {
+        return editableQuad != initialQuad || history.canUndo
+    }
+
+    fun revertToInitial() {
+        editableQuad = initialQuad
+        history.clear()
+    }
 }

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreenState.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/EditPageScreenState.kt
@@ -29,6 +29,15 @@ class EditPageScreenState {
     var draggedCornerIndex by mutableIntStateOf(-1)
     var draggedEdgeIndex by mutableIntStateOf(-1)
     var dragPosition by mutableStateOf<Offset?>(null)
+    /** True from the moment the finger touches a drag handle until it is lifted. */
+    var isTouching by mutableStateOf(false)
+    /**
+     * Corner / edge index detected at the raw touch-down (before touch-slop).
+     * Carried into [startCornerDrag] / [startEdgeDrag] so that the slop-adjusted
+     * position in onDragStart cannot miss the handle.
+     */
+    var touchDownCornerIndex by mutableIntStateOf(-1)
+    var touchDownEdgeIndex by mutableIntStateOf(-1)
 
     val history = QuadEditingHistory()
     private var quadBeforeDrag: Quad? = null
@@ -62,7 +71,29 @@ class EditPageScreenState {
         quadBeforeDrag = null
         draggedCornerIndex = -1
         draggedEdgeIndex = -1
-        dragPosition = null
+        // dragPosition is intentionally kept so the loupe can still render
+        // during its 1-second fade-out after the finger is lifted.
+    }
+
+    /**
+     * Called as soon as the finger touches a drag handle (before touch-slop),
+     * so the loupe is shown immediately.
+     * [cornerIndex] / [edgeIndex] are the handle indices found at the exact
+     * touch position; they are stored so that [onDragStart] can use them even
+     * if the slop-adjusted position drifts outside the hit-test radius.
+     */
+    fun onTouchDown(position: Offset, cornerIndex: Int = -1, edgeIndex: Int = -1) {
+        isTouching = true
+        dragPosition = position
+        touchDownCornerIndex = cornerIndex
+        touchDownEdgeIndex = edgeIndex
+    }
+
+    /** Called when the finger is lifted; triggers the loupe fade-out delay. */
+    fun onTouchUp() {
+        isTouching = false
+        touchDownCornerIndex = -1
+        touchDownEdgeIndex = -1
     }
 
     fun undo() {

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/MagnifyingGlass.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/MagnifyingGlass.kt
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2026 Philipp Hasper
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.fairscan.app.ui.screens.edit
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
+
+private val LOUPE_BORDER_WIDTH = 3.dp
+private const val ZOOM_FACTOR = 3f
+
+/**
+ * Layout parameters for the magnifying-glass loupe.
+ *
+ * Use `LoupeLayoutConfig<Dp>` in Compose UI code and [toPx] to convert to
+ * `LoupeLayoutConfig<Float>` for pixel-level calculations.
+ */
+data class LoupeLayoutConfig<T>(
+    /** Radius of the loupe circle */
+    val loupeRadius: T,
+    /** Gap between the finger and the nearest edge of the loupe */
+    val verticalOffset: T,
+    /** Minimum space between the loupe and the screen edge */
+    val screenMargin: T,
+) {
+    companion object {
+        val Default = LoupeLayoutConfig(
+            loupeRadius = 60.dp,
+            verticalOffset = 40.dp,
+            screenMargin = 8.dp,
+        )
+    }
+}
+
+/** Convert a dp-valued config to pixels using the current [LocalDensity]. */
+@Composable
+internal fun LoupeLayoutConfig<Dp>.toPx(): LoupeLayoutConfig<Float> {
+    val density = LocalDensity.current
+    return with(density) {
+        LoupeLayoutConfig(
+            loupeRadius = loupeRadius.toPx(),
+            verticalOffset = verticalOffset.toPx(),
+            screenMargin = screenMargin.toPx(),
+        )
+    }
+}
+
+/**
+ * Displays a magnifying glass / loupe showing a zoomed-in patch of [bitmap]
+ * centred around [focusPosition].
+ *
+ * Positioning rules:
+ *  1. By default, the loupe is placed **above** the finger.
+ *  2. If there is not enough room above, it moves to the **left** of the finger.
+ *  3. If there is not enough room on the left either, it moves to the **right**.
+ *
+ * @param bitmap          The full source bitmap (original image).
+ * @param fingerPosition  Current finger position in screen (container) coordinates, used for loupe placement.
+ * @param focusPosition   The exact point to zoom into (e.g. corner or edge midpoint) in screen coordinates.
+ * @param containerSize   Size of the full-screen container.
+ * @param displaySize     Size of the image as rendered (letterboxed inside the container).
+ */
+@Composable
+fun MagnifyingGlass(
+    bitmap: Bitmap,
+    fingerPosition: Offset,
+    focusPosition: Offset,
+    containerSize: IntSize,
+    displaySize: IntSize,
+    configDp: LoupeLayoutConfig<Dp> = LoupeLayoutConfig.Default,
+) {
+    val density = LocalDensity.current
+    val configPx = configDp.toPx()
+    val borderWidth = with(density) { LOUPE_BORDER_WIDTH.toPx() }
+
+    // compute loupe centre position
+    val loupeCenter = computeLoupeCenter(
+        dragPosition = fingerPosition,
+        configPx = configPx,
+        containerWidth = containerSize.width.toFloat(),
+    )
+
+    // compute the bitmap region to sample
+    val imageOffset = QuadCoordinateUtils.getImageOffset(containerSize, displaySize)
+
+    // Focus position mapped to bitmap pixel coordinates
+    val bitmapX = ((focusPosition.x - imageOffset.width) / displaySize.width * bitmap.width)
+        .coerceIn(0f, (bitmap.width - 1).toFloat())
+    val bitmapY = ((focusPosition.y - imageOffset.height) / displaySize.height * bitmap.height)
+        .coerceIn(0f, (bitmap.height - 1).toFloat())
+
+    // How many bitmap pixels the loupe shows in each direction
+    val bitmapRegionHalf = (bitmap.width / displaySize.width.toFloat()) * configPx.loupeRadius / ZOOM_FACTOR
+
+    val imageBitmap = remember(bitmap) { bitmap.asImageBitmap() }
+
+    val borderColor = MaterialTheme.colorScheme.primary
+    val crosshairColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
+    val backgroundColor = MaterialTheme.colorScheme.background
+
+    Canvas(
+        modifier = Modifier
+            .size(configDp.loupeRadius * 2)
+            .layout { measurable, constraints ->
+                val placeable = measurable.measure(constraints)
+                layout(placeable.width, placeable.height) {
+                    placeable.placeRelative(
+                        IntOffset(
+                            (loupeCenter.x - configPx.loupeRadius).roundToInt(),
+                            (loupeCenter.y - configPx.loupeRadius).roundToInt()
+                        )
+                    )
+                }
+            }
+    ) {
+        val circlePath = Path().apply {
+            addOval(
+                androidx.compose.ui.geometry.Rect(
+                    0f, 0f, configPx.loupeRadius * 2, configPx.loupeRadius * 2
+                )
+            )
+        }
+
+        clipPath(circlePath) {
+            // Fill background so areas outside the image are opaque
+            drawRect(color = backgroundColor)
+
+            // Source rect in bitmap coordinates
+            val srcLeft = (bitmapX - bitmapRegionHalf).toInt().coerceAtLeast(0)
+            val srcTop = (bitmapY - bitmapRegionHalf).toInt().coerceAtLeast(0)
+            val srcRight = (bitmapX + bitmapRegionHalf).toInt().coerceAtMost(bitmap.width)
+            val srcBottom = (bitmapY + bitmapRegionHalf).toInt().coerceAtMost(bitmap.height)
+
+            if (srcRight > srcLeft && srcBottom > srcTop) {
+
+                // Destination offset – compensate when the source rect was clamped
+                val dstOffsetX = ((srcLeft - (bitmapX - bitmapRegionHalf)) / (2 * bitmapRegionHalf) * configPx.loupeRadius * 2)
+                val dstOffsetY = ((srcTop - (bitmapY - bitmapRegionHalf)) / (2 * bitmapRegionHalf) * configPx.loupeRadius * 2)
+
+                val dstWidth = ((srcRight - srcLeft) / (2 * bitmapRegionHalf) * configPx.loupeRadius * 2).toInt()
+                val dstHeight = ((srcBottom - srcTop) / (2 * bitmapRegionHalf) * configPx.loupeRadius * 2).toInt()
+
+                drawImage(
+                    image = imageBitmap,
+                    srcOffset = IntOffset(srcLeft, srcTop),
+                    srcSize = IntSize(srcRight - srcLeft, srcBottom - srcTop),
+                    dstOffset = IntOffset(dstOffsetX.toInt(), dstOffsetY.toInt()),
+                    dstSize = IntSize(dstWidth, dstHeight),
+                )
+            }
+
+            // Crosshair
+            val center = Offset(configPx.loupeRadius, configPx.loupeRadius)
+            val crosshairLen = configPx.loupeRadius * 0.25f
+            drawLine(crosshairColor, Offset(center.x - crosshairLen, center.y), Offset(center.x + crosshairLen, center.y), strokeWidth = 2f)
+            drawLine(crosshairColor, Offset(center.x, center.y - crosshairLen), Offset(center.x, center.y + crosshairLen), strokeWidth = 2f)
+        }
+
+        // Border
+        drawCircle(
+            color = borderColor,
+            radius = configPx.loupeRadius - borderWidth / 2,
+            center = Offset(configPx.loupeRadius, configPx.loupeRadius),
+            style = Stroke(width = borderWidth)
+        )
+    }
+}
+
+/**
+ * Decides where the loupe centre should be.
+ *
+ * Priority:
+ *  1. Above the finger (centred horizontally, clamped to screen edges).
+ *  2. If no vertical room -> to the left.
+ *  3. If no room on the left -> to the right.
+ */
+internal fun computeLoupeCenter(
+    dragPosition: Offset,
+    configPx: LoupeLayoutConfig<Float>,
+    containerWidth: Float,
+): Offset {
+    val loupeRadius = configPx.loupeRadius
+    val verticalOffset = configPx.verticalOffset
+    val screenMargin = configPx.screenMargin
+
+    // Try above
+    val aboveCenterY = dragPosition.y - verticalOffset - loupeRadius
+    if (aboveCenterY - loupeRadius >= screenMargin) {
+        // Enough room above -> place centred horizontally on the finger, clamped to screen edges
+        val cx = dragPosition.x.coerceIn(screenMargin + loupeRadius, containerWidth - screenMargin - loupeRadius)
+        return Offset(cx, aboveCenterY)
+    }
+
+    // Not enough room above -> try left
+    val leftCenterX = dragPosition.x - verticalOffset - loupeRadius
+    if (leftCenterX - loupeRadius >= screenMargin) {
+        val cy = dragPosition.y.coerceIn(screenMargin + loupeRadius, Float.MAX_VALUE)
+        return Offset(leftCenterX, cy)
+    }
+
+    // Not enough room on the left -> place right
+    val rightCenterX = dragPosition.x + verticalOffset + loupeRadius
+    val cx = rightCenterX.coerceAtMost(containerWidth - screenMargin - loupeRadius)
+    val cy = dragPosition.y.coerceIn(screenMargin + loupeRadius, Float.MAX_VALUE)
+    return Offset(cx, cy)
+}

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/MagnifyingGlass.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/MagnifyingGlass.kt
@@ -22,17 +22,22 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.graphics.ClipOp
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.fairscan.imageprocessing.Quad
+import kotlin.math.ceil
+import kotlin.math.floor
 import kotlin.math.roundToInt
 
 private val LOUPE_BORDER_WIDTH = 3.dp
@@ -178,7 +183,7 @@ fun MagnifyingGlass(
                 )
             }
 
-            // Draw quad edges inside the loupe
+            // Draw quad overlay and edges inside the loupe
             // Convert each normalized quad corner to bitmap-pixel coords,
             // then to loupe-local coords using the same mapping as the bitmap sampling.
             if (quad != null) {
@@ -202,6 +207,49 @@ fun MagnifyingGlass(
                     normalizedToLoupe(quad.bottomLeft.x, quad.bottomLeft.y),
                 )
 
+                // Striped overlay outside the quad to distinguish document from background
+                val quadPath = Path().apply {
+                    moveTo(loupeCorners[0].x, loupeCorners[0].y)
+                    for (corner in loupeCorners.drop(1)) {
+                        lineTo(corner.x, corner.y)
+                    }
+                    close()
+                }
+                clipPath(quadPath, clipOp = ClipOp.Difference) {
+                    // Clip to actual image bounds so stripes only appear over
+                    // image content, not in the background area near edges.
+                    val imgLeft = -bitmapOriginX * scale
+                    val imgTop = -bitmapOriginY * scale
+                    val imgRight = (bitmap.width - bitmapOriginX) * scale
+                    val imgBottom = (bitmap.height - bitmapOriginY) * scale
+
+                    clipRect(
+                        left = imgLeft, top = imgTop,
+                        right = imgRight, bottom = imgBottom
+                    ) {
+                        val stripeSpacing = 50f
+                        val stripeWidth = 10f
+                        val stripeColor = Color.Gray.copy(alpha = 0.35f)
+
+                        // Stripes are placed at fixed positions in bitmap coordinate
+                        // space so they scroll with the image as the loupe pans.
+                        val originShift = (bitmapOriginX + bitmapOriginY) * scale
+                        val kMin = floor(originShift / stripeSpacing).toInt() - 1
+                        val kMax = ceil((originShift + 2f * loupeDiameter) / stripeSpacing).toInt() + 1
+
+                        for (k in kMin..kMax) {
+                            val loupeSum = k * stripeSpacing - originShift
+                            drawLine(
+                                color = stripeColor,
+                                start = Offset(loupeSum, 0f),
+                                end = Offset(0f, loupeSum),
+                                strokeWidth = stripeWidth,
+                            )
+                        }
+                    }
+                }
+
+                // Draw quad edge lines on top
                 for (i in 0 until 4) {
                     drawLine(
                         color = quadLineColor,

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/MagnifyingGlass.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/MagnifyingGlass.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import org.fairscan.imageprocessing.Quad
 import kotlin.math.roundToInt
 
 private val LOUPE_BORDER_WIDTH = 3.dp
@@ -95,6 +96,7 @@ fun MagnifyingGlass(
     focusPosition: Offset,
     containerSize: IntSize,
     displaySize: IntSize,
+    quad: Quad? = null,
     configDp: LoupeLayoutConfig<Dp> = LoupeLayoutConfig.Default,
 ) {
     val density = LocalDensity.current
@@ -123,7 +125,7 @@ fun MagnifyingGlass(
     val imageBitmap = remember(bitmap) { bitmap.asImageBitmap() }
 
     val borderColor = MaterialTheme.colorScheme.primary
-    val crosshairColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
+    val quadLineColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.8f)
     val backgroundColor = MaterialTheme.colorScheme.background
 
     Canvas(
@@ -141,11 +143,10 @@ fun MagnifyingGlass(
                 }
             }
     ) {
+        val loupeDiameter = configPx.loupeRadius * 2
         val circlePath = Path().apply {
             addOval(
-                androidx.compose.ui.geometry.Rect(
-                    0f, 0f, configPx.loupeRadius * 2, configPx.loupeRadius * 2
-                )
+                androidx.compose.ui.geometry.Rect(0f, 0f, loupeDiameter, loupeDiameter)
             )
         }
 
@@ -162,11 +163,11 @@ fun MagnifyingGlass(
             if (srcRight > srcLeft && srcBottom > srcTop) {
 
                 // Destination offset – compensate when the source rect was clamped
-                val dstOffsetX = ((srcLeft - (bitmapX - bitmapRegionHalf)) / (2 * bitmapRegionHalf) * configPx.loupeRadius * 2)
-                val dstOffsetY = ((srcTop - (bitmapY - bitmapRegionHalf)) / (2 * bitmapRegionHalf) * configPx.loupeRadius * 2)
+                val dstOffsetX = ((srcLeft - (bitmapX - bitmapRegionHalf)) / (2 * bitmapRegionHalf) * loupeDiameter)
+                val dstOffsetY = ((srcTop - (bitmapY - bitmapRegionHalf)) / (2 * bitmapRegionHalf) * loupeDiameter)
 
-                val dstWidth = ((srcRight - srcLeft) / (2 * bitmapRegionHalf) * configPx.loupeRadius * 2).toInt()
-                val dstHeight = ((srcBottom - srcTop) / (2 * bitmapRegionHalf) * configPx.loupeRadius * 2).toInt()
+                val dstWidth = ((srcRight - srcLeft) / (2 * bitmapRegionHalf) * loupeDiameter).toInt()
+                val dstHeight = ((srcBottom - srcTop) / (2 * bitmapRegionHalf) * loupeDiameter).toInt()
 
                 drawImage(
                     image = imageBitmap,
@@ -177,11 +178,39 @@ fun MagnifyingGlass(
                 )
             }
 
-            // Crosshair
-            val center = Offset(configPx.loupeRadius, configPx.loupeRadius)
-            val crosshairLen = configPx.loupeRadius * 0.25f
-            drawLine(crosshairColor, Offset(center.x - crosshairLen, center.y), Offset(center.x + crosshairLen, center.y), strokeWidth = 2f)
-            drawLine(crosshairColor, Offset(center.x, center.y - crosshairLen), Offset(center.x, center.y + crosshairLen), strokeWidth = 2f)
+            // Draw quad edges inside the loupe
+            // Convert each normalized quad corner to bitmap-pixel coords,
+            // then to loupe-local coords using the same mapping as the bitmap sampling.
+            if (quad != null) {
+                val bitmapOriginX = bitmapX - bitmapRegionHalf
+                val bitmapOriginY = bitmapY - bitmapRegionHalf
+                val scale = loupeDiameter / (2 * bitmapRegionHalf)
+
+                fun normalizedToLoupe(nx: Double, ny: Double): Offset {
+                    val bx = (nx * bitmap.width).toFloat()
+                    val by = (ny * bitmap.height).toFloat()
+                    return Offset(
+                        (bx - bitmapOriginX) * scale,
+                        (by - bitmapOriginY) * scale
+                    )
+                }
+
+                val loupeCorners = listOf(
+                    normalizedToLoupe(quad.topLeft.x, quad.topLeft.y),
+                    normalizedToLoupe(quad.topRight.x, quad.topRight.y),
+                    normalizedToLoupe(quad.bottomRight.x, quad.bottomRight.y),
+                    normalizedToLoupe(quad.bottomLeft.x, quad.bottomLeft.y),
+                )
+
+                for (i in 0 until 4) {
+                    drawLine(
+                        color = quadLineColor,
+                        start = loupeCorners[i],
+                        end = loupeCorners[(i + 1) % 4],
+                        strokeWidth = 3f
+                    )
+                }
+            }
         }
 
         // Border

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/QuadCoordinateUtils.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/QuadCoordinateUtils.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Philipp Hasper
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.fairscan.app.ui.screens.edit
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntSize
+import org.fairscan.imageprocessing.Point
+
+object QuadCoordinateUtils {
+
+    fun calculateDisplaySize(
+        bitmapWidth: Int,
+        bitmapHeight: Int,
+        containerSize: IntSize
+    ): IntSize {
+        val imageAspectRatio = bitmapWidth.toFloat() / bitmapHeight.toFloat()
+        val containerAspectRatio = containerSize.width / containerSize.height.toFloat()
+
+        return if (imageAspectRatio > containerAspectRatio) {
+            IntSize(containerSize.width, (containerSize.width / imageAspectRatio).toInt())
+        } else {
+            IntSize((containerSize.height * imageAspectRatio).toInt(), containerSize.height)
+        }
+    }
+
+    fun normalizedToScreen(point: Point, containerSize: IntSize, displaySize: IntSize): Offset {
+        val offsetX = (containerSize.width - displaySize.width) / 2
+        val offsetY = (containerSize.height - displaySize.height) / 2
+        return Offset(
+            x = (point.x * displaySize.width).toFloat() + offsetX,
+            y = (point.y * displaySize.height).toFloat() + offsetY
+        )
+    }
+
+    fun screenDeltaToNormalized(delta: Offset, displaySize: IntSize): Offset {
+        return Offset(
+            x = delta.x / displaySize.width,
+            y = delta.y / displaySize.height
+        )
+    }
+
+    fun getImageOffset(containerSize: IntSize, displaySize: IntSize): IntSize {
+        return IntSize(
+            (containerSize.width - displaySize.width) / 2,
+            (containerSize.height - displaySize.height) / 2
+        )
+    }
+}

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/QuadEditingHandler.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/QuadEditingHandler.kt
@@ -54,18 +54,19 @@ class QuadEditingHandler {
 
     fun updateQuadCorner(quad: Quad, cornerIndex: Int, delta: Offset): Quad {
         val normalizedDelta = Point(delta.x.toDouble(), delta.y.toDouble())
-        return when (cornerIndex) {
+        val candidate = when (cornerIndex) {
             0 -> quad.copy(topLeft = clampPoint(quad.topLeft + normalizedDelta))
             1 -> quad.copy(topRight = clampPoint(quad.topRight + normalizedDelta))
             2 -> quad.copy(bottomRight = clampPoint(quad.bottomRight + normalizedDelta))
             3 -> quad.copy(bottomLeft = clampPoint(quad.bottomLeft + normalizedDelta))
             else -> quad
         }
+        return if (candidate.isConvex()) candidate else quad
     }
 
     fun updateQuadEdge(quad: Quad, edgeIndex: Int, delta: Offset): Quad {
         val normalizedDelta = Point(delta.x.toDouble(), delta.y.toDouble())
-        return when (edgeIndex) {
+        val candidate = when (edgeIndex) {
             0 -> quad.copy( // top edge
                 topLeft = clampPoint(quad.topLeft + normalizedDelta),
                 topRight = clampPoint(quad.topRight + normalizedDelta)
@@ -84,6 +85,7 @@ class QuadEditingHandler {
             )
             else -> quad
         }
+        return if (candidate.isConvex()) candidate else quad
     }
 
     private fun getCornerPositions(quad: Quad, containerSize: IntSize, displaySize: IntSize): List<Offset> {

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/QuadEditingHandler.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/QuadEditingHandler.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Philipp Hasper
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.fairscan.app.ui.screens.edit
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.unit.IntSize
+import org.fairscan.imageprocessing.Point
+import org.fairscan.imageprocessing.Quad
+
+class QuadEditingHandler {
+
+    companion object {
+        const val CORNER_RADIUS = 40f
+        val EDGE_HANDLE_SIZE = Size(90f, 40f)
+    }
+
+    fun findTouchedCorner(
+        touchPos: Offset,
+        quad: Quad,
+        containerSize: IntSize,
+        displaySize: IntSize
+    ): Int {
+        val corners = getCornerPositions(quad, containerSize, displaySize)
+        return corners.indexOfFirst { corner ->
+            (touchPos - corner).getDistance() < CORNER_RADIUS * 1.5f
+        }
+    }
+
+    fun findTouchedEdge(
+        touchPos: Offset,
+        quad: Quad,
+        containerSize: IntSize,
+        displaySize: IntSize
+    ): Int {
+        val corners = getCornerPositions(quad, containerSize, displaySize)
+        val edgeMidpoints = getEdgeMidpoints(corners)
+        return edgeMidpoints.indexOfFirst { midpoint ->
+            (touchPos - midpoint).getDistance() < EDGE_HANDLE_SIZE.width
+        }
+    }
+
+    fun updateQuadCorner(quad: Quad, cornerIndex: Int, delta: Offset): Quad {
+        val normalizedDelta = Point(delta.x.toDouble(), delta.y.toDouble())
+        return when (cornerIndex) {
+            0 -> quad.copy(topLeft = clampPoint(quad.topLeft + normalizedDelta))
+            1 -> quad.copy(topRight = clampPoint(quad.topRight + normalizedDelta))
+            2 -> quad.copy(bottomRight = clampPoint(quad.bottomRight + normalizedDelta))
+            3 -> quad.copy(bottomLeft = clampPoint(quad.bottomLeft + normalizedDelta))
+            else -> quad
+        }
+    }
+
+    fun updateQuadEdge(quad: Quad, edgeIndex: Int, delta: Offset): Quad {
+        val normalizedDelta = Point(delta.x.toDouble(), delta.y.toDouble())
+        return when (edgeIndex) {
+            0 -> quad.copy( // top edge
+                topLeft = clampPoint(quad.topLeft + normalizedDelta),
+                topRight = clampPoint(quad.topRight + normalizedDelta)
+            )
+            1 -> quad.copy( // right edge
+                topRight = clampPoint(quad.topRight + normalizedDelta),
+                bottomRight = clampPoint(quad.bottomRight + normalizedDelta)
+            )
+            2 -> quad.copy( // bottom edge
+                bottomRight = clampPoint(quad.bottomRight + normalizedDelta),
+                bottomLeft = clampPoint(quad.bottomLeft + normalizedDelta)
+            )
+            3 -> quad.copy( // left edge
+                bottomLeft = clampPoint(quad.bottomLeft + normalizedDelta),
+                topLeft = clampPoint(quad.topLeft + normalizedDelta)
+            )
+            else -> quad
+        }
+    }
+
+    private fun getCornerPositions(quad: Quad, containerSize: IntSize, displaySize: IntSize): List<Offset> {
+        return listOf(
+            QuadCoordinateUtils.normalizedToScreen(quad.topLeft, containerSize, displaySize),
+            QuadCoordinateUtils.normalizedToScreen(quad.topRight, containerSize, displaySize),
+            QuadCoordinateUtils.normalizedToScreen(quad.bottomRight, containerSize, displaySize),
+            QuadCoordinateUtils.normalizedToScreen(quad.bottomLeft, containerSize, displaySize)
+        )
+    }
+
+    private fun getEdgeMidpoints(corners: List<Offset>): List<Offset> {
+        return listOf(
+            Offset((corners[0].x + corners[1].x) / 2, (corners[0].y + corners[1].y) / 2),
+            Offset((corners[1].x + corners[2].x) / 2, (corners[1].y + corners[2].y) / 2),
+            Offset((corners[2].x + corners[3].x) / 2, (corners[2].y + corners[3].y) / 2),
+            Offset((corners[3].x + corners[0].x) / 2, (corners[3].y + corners[0].y) / 2)
+        )
+    }
+
+    private fun clampPoint(point: Point): Point {
+        return Point(
+            point.x.coerceIn(0.0, 1.0),
+            point.y.coerceIn(0.0, 1.0)
+        )
+    }
+
+    private operator fun Point.plus(other: Point): Point {
+        return Point(this.x + other.x, this.y + other.y)
+    }
+}

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/QuadEditingHistory.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/QuadEditingHistory.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Philipp Hasper
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.fairscan.app.ui.screens.edit
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import org.fairscan.imageprocessing.Quad
+
+class QuadEditingHistory {
+    private val undoStack = mutableListOf<Quad>()
+    private val redoStack = mutableListOf<Quad>()
+
+    var canUndo by mutableStateOf(false)
+        private set
+    var canRedo by mutableStateOf(false)
+        private set
+
+    fun pushState(quad: Quad) {
+        undoStack.add(quad)
+        redoStack.clear()
+        updateState()
+    }
+
+    fun undo(currentQuad: Quad): Quad? {
+        if (undoStack.isEmpty()) return null
+
+        redoStack.add(currentQuad)
+        val previousState = undoStack.removeAt(undoStack.lastIndex)
+        updateState()
+        return previousState
+    }
+
+    fun redo(currentQuad: Quad): Quad? {
+        if (redoStack.isEmpty()) return null
+
+        undoStack.add(currentQuad)
+        val nextState = redoStack.removeAt(redoStack.lastIndex)
+        updateState()
+        return nextState
+    }
+
+    fun clear() {
+        undoStack.clear()
+        redoStack.clear()
+        updateState()
+    }
+
+    private fun updateState() {
+        canUndo = undoStack.isNotEmpty()
+        canRedo = redoStack.isNotEmpty()
+    }
+}

--- a/app/src/main/java/org/fairscan/app/ui/screens/edit/QuadOverlay.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/edit/QuadOverlay.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 Philipp Hasper
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.fairscan.app.ui.screens.edit
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.unit.IntSize
+import org.fairscan.imageprocessing.Point
+import org.fairscan.imageprocessing.Quad
+import org.fairscan.imageprocessing.scaledTo
+import kotlin.math.atan2
+
+@Composable
+fun QuadOverlay(
+    quad: Quad,
+    containerSize: IntSize,
+    displaySize: IntSize,
+    modifier: Modifier = Modifier
+) {
+    val quadColor = MaterialTheme.colorScheme.primary
+    val handleColor = quadColor.copy(alpha = 0.5f)
+
+    Canvas(modifier = modifier.fillMaxSize()) {
+        val scaledQuad = quad.scaledTo(
+            fromWidth = 1,
+            fromHeight = 1,
+            toWidth = displaySize.width,
+            toHeight = displaySize.height
+        )
+
+        val offset = QuadCoordinateUtils.getImageOffset(containerSize, displaySize)
+        val corners = listOf(
+            scaledQuad.topLeft.toOffset(),
+            scaledQuad.topRight.toOffset(),
+            scaledQuad.bottomRight.toOffset(),
+            scaledQuad.bottomLeft.toOffset()
+        ).map { it.copy(x = it.x + offset.width, y = it.y + offset.height) }
+
+        // Draw edges
+        for (i in 0 until 4) {
+            drawLine(
+                color = quadColor,
+                start = corners[i],
+                end = corners[(i + 1) % 4],
+                strokeWidth = 10.0f
+            )
+        }
+
+        // Draw corner handles
+        corners.forEach { corner ->
+            drawCircle(
+                color = handleColor,
+                radius = QuadEditingHandler.CORNER_RADIUS,
+                center = corner
+            )
+        }
+
+        // Draw edge handles
+        drawEdgeHandles(corners, handleColor)
+    }
+}
+
+private fun DrawScope.drawEdgeHandles(
+    corners: List<Offset>,
+    handleColor: androidx.compose.ui.graphics.Color
+) {
+    for (i in 0 until 4) {
+        val from = corners[i]
+        val to = corners[(i + 1) % 4]
+        val midpoint = Offset((from.x + to.x) / 2, (from.y + to.y) / 2)
+
+        val edgeAngle = atan2(
+            (to.y - from.y).toDouble(),
+            (to.x - from.x).toDouble()
+        ) * 180 / Math.PI
+
+        rotate(degrees = edgeAngle.toFloat(), pivot = midpoint) {
+            val cornerRadius = QuadEditingHandler.EDGE_HANDLE_SIZE.height / 2
+            drawRoundRect(
+                color = handleColor,
+                topLeft = Offset(
+                    midpoint.x - QuadEditingHandler.EDGE_HANDLE_SIZE.width / 2,
+                    midpoint.y - QuadEditingHandler.EDGE_HANDLE_SIZE.height / 2
+                ),
+                size = QuadEditingHandler.EDGE_HANDLE_SIZE,
+                cornerRadius = CornerRadius(cornerRadius, cornerRadius)
+            )
+        }
+    }
+}
+
+fun Point.toOffset() = Offset(x.toFloat(), y.toFloat())

--- a/app/src/main/java/org/fairscan/app/ui/screens/settings/SettingsRepository.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/settings/SettingsRepository.kt
@@ -16,6 +16,7 @@ package org.fairscan.app.ui.screens.settings
 
 import android.content.Context
 import androidx.core.net.toUri
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -31,6 +32,7 @@ class SettingsRepository(private val context: Context) {
     private val EXPORT_DIR_URI = stringPreferencesKey("export_dir_uri")
     private val EXPORT_FORMAT = stringPreferencesKey("export_format")
     private val EXPORT_QUALITY = stringPreferencesKey("export_quality")
+    private val IMAGE_EDITING_ENABLED = booleanPreferencesKey("image_editing_enabled")
 
     val exportDirUri: Flow<String?> =
         context.dataStore.data.map { prefs ->
@@ -79,6 +81,17 @@ class SettingsRepository(private val context: Context) {
     suspend fun setExportQuality(quality: ExportQuality) {
         context.dataStore.edit { prefs ->
             prefs[EXPORT_QUALITY] = quality.name
+        }
+    }
+
+    val imageEditingEnabled: Flow<Boolean> =
+        context.dataStore.data.map { prefs ->
+            prefs[IMAGE_EDITING_ENABLED] ?: false
+        }
+
+    suspend fun setImageEditingEnabled(enabled: Boolean) {
+        context.dataStore.edit { prefs ->
+            prefs[IMAGE_EDITING_ENABLED] = enabled
         }
     }
 }

--- a/app/src/main/java/org/fairscan/app/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/settings/SettingsScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -58,6 +59,7 @@ fun SettingsScreen(
     onResetExportDirClick: () -> Unit,
     onExportFormatChanged: (ExportFormat) -> Unit,
     onExportQualityChanged: (ExportQuality) -> Unit,
+    onImageEditingEnabledChanged: (Boolean) -> Unit,
     onBack: () -> Unit,
 ) {
     BackHandler { onBack() }
@@ -75,6 +77,7 @@ fun SettingsScreen(
             onResetExportDirClick,
             onExportFormatChanged,
             onExportQualityChanged,
+            onImageEditingEnabledChanged,
             modifier = Modifier.padding(paddingValues))
     }
 }
@@ -86,6 +89,7 @@ private fun SettingsContent(
     onResetExportDirClick: () -> Unit,
     onExportFormatChanged: (ExportFormat) -> Unit,
     onExportQualityChanged: (ExportQuality) -> Unit,
+    onImageEditingEnabledChanged: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val (folderLabel, folderLabelColor) = when {
@@ -159,6 +163,22 @@ private fun SettingsContent(
             )
             Text("JPEG")
         }
+
+        Spacer(Modifier.height(32.dp))
+
+        Text(stringResource(R.string.features), style = MaterialTheme.typography.titleLarge)
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(stringResource(R.string.image_editing_setting))
+            Switch(
+                checked = uiState.imageEditingEnabled,
+                onCheckedChange = onImageEditingEnabledChanged
+            )
+        }
     }
 }
 
@@ -227,6 +247,7 @@ fun SettingsScreenPreview(uiState: SettingsUiState) {
             onResetExportDirClick = {},
             onExportFormatChanged = {},
             onExportQualityChanged = {},
+            onImageEditingEnabledChanged = {},
             onBack = {}
         )
     }

--- a/app/src/main/java/org/fairscan/app/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/settings/SettingsViewModel.kt
@@ -31,6 +31,7 @@ data class SettingsUiState(
     val exportDirName: String? = null,
     val exportFormat: ExportFormat = ExportFormat.PDF,
     val exportQuality: ExportQuality = ExportQuality.BALANCED,
+    val imageEditingEnabled: Boolean = false,
 )
 
 class SettingsViewModel(container: AppContainer) : ViewModel() {
@@ -45,12 +46,14 @@ class SettingsViewModel(container: AppContainer) : ViewModel() {
         dirName,
         repo.exportFormat,
         repo.exportQuality,
-    ) { uri, name, format, quality ->
+        repo.imageEditingEnabled,
+    ) { uri, name, format, quality, imageEditingEnabled ->
         SettingsUiState(
             exportDirUri = uri,
             exportDirName = name,
             exportFormat = format,
             exportQuality = quality,
+            imageEditingEnabled = imageEditingEnabled,
         )
     }.stateIn(
         viewModelScope,
@@ -74,6 +77,12 @@ class SettingsViewModel(container: AppContainer) : ViewModel() {
     fun setExportQuality(quality: ExportQuality) {
         viewModelScope.launch {
             repo.setExportQuality(quality)
+        }
+    }
+
+    fun setImageEditingEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            repo.setImageEditingEnabled(enabled)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,7 @@
     <string name="view_full_list">View full list</string>
     <string name="view_the_full_license">View the full license</string>
     <string name="yes">Yes</string>
+    <string name="report">Report</string>
     <plurals name="files_saved_to">
         <item quantity="one">%2$s saved to %3$s</item>
         <item quantity="other">%1$d files saved to %3$s</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="camera_permission_denied">Camera permission was denied</string>
     <string name="camera_permission_rationale">The app requires camera access to scan documents. Captured images are stored only on this device and will be deleted when you close the current document.</string>
     <string name="cancel">Cancel</string>
+    <string name="confirm">Confirm</string>
     <string name="change_directory">Change folder</string>
     <string name="clear_text">Clear text</string>
     <string name="contact">Contact</string>
@@ -56,6 +57,7 @@
     <string name="new_document_warning">The current scan will be lost. Do you want to continue?</string>
     <string name="open">Open</string>
     <string name="open_file">Open file</string>
+    <string name="redo">Redo</string>
     <string name="reset_to_default">Reset to default</string>
     <string name="resume">Resume</string>
     <string name="rotate_left">Rotate left</string>
@@ -71,6 +73,7 @@
     <string name="support_last_image">Report a problem with last captured image</string>
     <string name="turn_off_torch">Turn off torch</string>
     <string name="turn_on_torch">Turn on torch</string>
+    <string name="undo">Undo</string>
     <string name="unknown_size">Unknown size</string>
     <string name="version">Version</string>
     <string name="view_full_list">View full list</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,8 @@
     <string name="discard_changes_warning">You have unsaved changes. Do you want to discard them?</string>
     <string name="discard_scan">Discard scan</string>
     <string name="download_dirname">Downloads</string>
+    <string name="image_editing">Manual image editing</string>
+    <string name="image_editing_setting">Enable manual image editing</string>
     <string name="end_scan">End scan</string>
     <string name="error">Error: %1$s</string>
     <string name="error_context_folder">Export folder: %1$s</string>
@@ -40,6 +42,7 @@
     <string name="export_quality_low">Low</string>
     <string name="export_quality_balanced">Balanced</string>
     <string name="export_quality_high">High</string>
+    <string name="features">Features</string>
     <string name="file_size">File size: %1$s</string>
     <string name="file_size_total">Total size: %1$s</string>
     <string name="filename">Filename</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,8 @@
     <string name="delete_page">Delete page</string>
     <string name="delete_page_warning">Do you want to delete this page?</string>
     <string name="developer">Developer</string>
+    <string name="discard_changes">Discard changes</string>
+    <string name="discard_changes_warning">You have unsaved changes. Do you want to discard them?</string>
     <string name="discard_scan">Discard scan</string>
     <string name="download_dirname">Downloads</string>
     <string name="end_scan">End scan</string>

--- a/app/src/test/java/org/fairscan/app/data/ImageRepositoryTest.kt
+++ b/app/src/test/java/org/fairscan/app/data/ImageRepositoryTest.kt
@@ -320,6 +320,52 @@ class ImageRepositoryTest {
         assertThat(metadata!!.normalizedQuad).isEqualTo(newQuad)
     }
 
+    @Test
+    fun update_page_quad_rotation_handling() = runTest {
+        val extractRotations = mutableListOf<Int>()
+        val transformations = object : ImageTransformations {
+            override fun rotate(inputFile: File, outputFile: File, rotationDegrees: Int, jpegQuality: Int) {
+                inputFile.copyTo(outputFile, true)
+            }
+
+            override fun resize(inputFile: File, outputFile: File, maxSize: Int) {
+                outputFile.writeBytes(byteArrayOf(inputFile.readBytes()[0]))
+            }
+
+            override fun extractDocument(
+                inputFile: File,
+                outputFile: File,
+                normalizedQuad: Quad,
+                rotationDegrees: Int,
+                isColored: Boolean,
+                quality: ExportQuality
+            ) {
+                extractRotations.add(rotationDegrees)
+                outputFile.writeBytes(byteArrayOf(1))
+            }
+        }
+
+        val repo = ImageRepository(getFilesDir(), transformations, 200)
+        repo.add(byteArrayOf(10, 11, 12), byteArrayOf(20), metadata1) // baseRotation = R90
+        val id = repo.imageIds().last()
+
+        repo.rotate(id, true) // manualRotation = R90
+
+        val newQuad = Quad(
+            Point(.05, .06),
+            Point(.15, .07),
+            Point(.16, .16),
+            Point(.06, .11)
+        )
+
+        repo.updatePageQuad(id, newQuad)
+
+        assertThat(extractRotations).containsExactly(
+            R180.degrees, // current work file uses base + manual
+            R90.degrees   // R0 variant uses base only
+        )
+    }
+
     private fun scanDir(): File = File(getFilesDir(), SCAN_DIR_NAME)
     private fun sourceDir(): File = File(getFilesDir(), SOURCE_DIR_NAME)
 

--- a/app/src/test/java/org/fairscan/app/data/ImageRepositoryTest.kt
+++ b/app/src/test/java/org/fairscan/app/data/ImageRepositoryTest.kt
@@ -18,6 +18,7 @@ import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import org.fairscan.app.domain.ExportQuality
 import org.fairscan.app.domain.PageMetadata
 import org.fairscan.app.domain.PageViewKey
 import org.fairscan.app.domain.Rotation.R0
@@ -51,10 +52,21 @@ class ImageRepositoryTest {
     fun repo(): ImageRepository {
         val transformations = object : ImageTransformations {
             override fun rotate(inputFile: File, outputFile: File, rotationDegrees: Int, jpegQuality: Int) {
-                inputFile.copyTo(outputFile)
+                inputFile.copyTo(outputFile, true)
             }
             override fun resize(inputFile: File, outputFile: File, maxSize: Int) {
                 outputFile.writeBytes(byteArrayOf(inputFile.readBytes()[0]))
+            }
+
+            override fun extractDocument(
+                inputFile: File,
+                outputFile: File,
+                normalizedQuad: Quad,
+                rotationDegrees: Int,
+                isColored: Boolean,
+                quality: ExportQuality
+            ) {
+                inputFile.copyTo(outputFile, true)
             }
         }
         return ImageRepository(getFilesDir(), transformations, 200)
@@ -286,6 +298,26 @@ class ImageRepositoryTest {
 
         repo2.clear()
         assertThat(repo2.lastAddedSourceFile()).isNull()
+    }
+
+    @Test
+    fun update_page_quad_updates_metadata() = runTest {
+        val repo = repo()
+        repo.add(byteArrayOf(10, 11, 12), byteArrayOf(20), metadata1)
+        val id = repo.imageIds().last()
+
+        val newQuad = Quad(
+            Point(.05, .06),
+            Point(.15, .07),
+            Point(.16, .16),
+            Point(.06, .11)
+        )
+
+        repo.updatePageQuad(id, newQuad)
+
+        val metadata = repo.getPageMetadata(id)
+        assertThat(metadata).isNotNull()
+        assertThat(metadata!!.normalizedQuad).isEqualTo(newQuad)
     }
 
     private fun scanDir(): File = File(getFilesDir(), SCAN_DIR_NAME)

--- a/app/src/test/java/org/fairscan/app/ui/screens/edit/EditPageScreenStateTest.kt
+++ b/app/src/test/java/org/fairscan/app/ui/screens/edit/EditPageScreenStateTest.kt
@@ -14,6 +14,7 @@
  */
 package org.fairscan.app.ui.screens.edit
 
+import androidx.compose.ui.geometry.Offset
 import org.assertj.core.api.Assertions.assertThat
 import org.fairscan.imageprocessing.Point
 import org.fairscan.imageprocessing.Quad
@@ -45,6 +46,11 @@ class EditPageScreenStateTest {
         assertThat(state.draggedCornerIndex).isEqualTo(-1)
         assertThat(state.draggedEdgeIndex).isEqualTo(-1)
         assertThat(state.isDragging()).isFalse()
+        // Touch / loupe state
+        assertThat(state.isTouching).isFalse()
+        assertThat(state.touchDownCornerIndex).isEqualTo(-1)
+        assertThat(state.touchDownEdgeIndex).isEqualTo(-1)
+        assertThat(state.dragPosition).isNull()
     }
 
     @Test
@@ -132,5 +138,208 @@ class EditPageScreenStateTest {
         state.endDrag()
         assertThat(state.isDragging()).isFalse()
         assertThat(state.editableQuad).isEqualTo(testQuad)
+    }
+
+    // ── onTouchDown ──────────────────────────────────────────────────────────
+
+    @Test
+    fun onTouchDown_setsIsTouchingAndDragPosition() {
+        val state = EditPageScreenState()
+        val pos = Offset(100f, 200f)
+
+        state.onTouchDown(pos)
+
+        assertThat(state.isTouching).isTrue()
+        assertThat(state.dragPosition).isEqualTo(pos)
+        assertThat(state.touchDownCornerIndex).isEqualTo(-1)
+        assertThat(state.touchDownEdgeIndex).isEqualTo(-1)
+    }
+
+    @Test
+    fun onTouchDown_withCornerIndex_storesCornerIndex() {
+        val state = EditPageScreenState()
+
+        state.onTouchDown(Offset(50f, 50f), cornerIndex = 2)
+
+        assertThat(state.isTouching).isTrue()
+        assertThat(state.touchDownCornerIndex).isEqualTo(2)
+        assertThat(state.touchDownEdgeIndex).isEqualTo(-1)
+    }
+
+    @Test
+    fun onTouchDown_withEdgeIndex_storesEdgeIndex() {
+        val state = EditPageScreenState()
+
+        state.onTouchDown(Offset(50f, 50f), edgeIndex = 3)
+
+        assertThat(state.isTouching).isTrue()
+        assertThat(state.touchDownCornerIndex).isEqualTo(-1)
+        assertThat(state.touchDownEdgeIndex).isEqualTo(3)
+    }
+
+    @Test
+    fun onTouchDown_overwritesPreviousTouchDown() {
+        val state = EditPageScreenState()
+        state.onTouchDown(Offset(10f, 10f), cornerIndex = 0)
+
+        state.onTouchDown(Offset(50f, 50f), cornerIndex = 3)
+
+        assertThat(state.dragPosition).isEqualTo(Offset(50f, 50f))
+        assertThat(state.touchDownCornerIndex).isEqualTo(3)
+    }
+
+    // ── onTouchUp ────────────────────────────────────────────────────────────
+
+    @Test
+    fun onTouchUp_clearsIsTouchingAndTouchDownIndices() {
+        val state = EditPageScreenState()
+        state.onTouchDown(Offset(100f, 200f), cornerIndex = 1)
+
+        state.onTouchUp()
+
+        assertThat(state.isTouching).isFalse()
+        assertThat(state.touchDownCornerIndex).isEqualTo(-1)
+        assertThat(state.touchDownEdgeIndex).isEqualTo(-1)
+    }
+
+    @Test
+    fun onTouchUp_preservesDragPosition() {
+        val state = EditPageScreenState()
+        val pos = Offset(100f, 200f)
+        state.onTouchDown(pos, cornerIndex = 1)
+
+        state.onTouchUp()
+
+        // dragPosition must survive so the loupe can still render during its fade-out delay.
+        assertThat(state.dragPosition).isEqualTo(pos)
+    }
+
+    @Test
+    fun onTouchUp_whenNotTouching_isIdempotent() {
+        val state = EditPageScreenState()
+
+        state.onTouchUp()
+
+        assertThat(state.isTouching).isFalse()
+        assertThat(state.touchDownCornerIndex).isEqualTo(-1)
+        assertThat(state.touchDownEdgeIndex).isEqualTo(-1)
+    }
+
+    // ── endDrag ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun endDrag_preservesDragPosition() {
+        val state = EditPageScreenState()
+        state.setInitialQuad(testQuad)
+        val pos = Offset(100f, 200f)
+        state.onTouchDown(pos, cornerIndex = 0)
+        state.startCornerDrag(0)
+        state.updateQuad(updatedQuad)
+
+        state.endDrag()
+
+        // dragPosition must NOT be nulled so the loupe stays visible during the 1 s fade-out.
+        assertThat(state.dragPosition).isEqualTo(pos)
+        assertThat(state.draggedCornerIndex).isEqualTo(-1)
+        assertThat(state.draggedEdgeIndex).isEqualTo(-1)
+    }
+
+    @Test
+    fun endDrag_doesNotResetTouchDownIndices() {
+        val state = EditPageScreenState()
+        state.setInitialQuad(testQuad)
+        state.onTouchDown(Offset(100f, 200f), cornerIndex = 2)
+        state.startCornerDrag(2)
+
+        state.endDrag()
+
+        // touchDownCornerIndex is owned by onTouchUp(), not endDrag().
+        assertThat(state.touchDownCornerIndex).isEqualTo(2)
+        assertThat(state.touchDownEdgeIndex).isEqualTo(-1)
+    }
+
+    // ── full interaction cycles ───────────────────────────────────────────────
+
+    @Test
+    fun tapCycle_leavesStateConsistent() {
+        val state = EditPageScreenState()
+        val pos = Offset(100f, 200f)
+
+        state.onTouchDown(pos, cornerIndex = 3)
+        assertThat(state.isTouching).isTrue()
+        assertThat(state.touchDownCornerIndex).isEqualTo(3)
+
+        state.onTouchUp()
+
+        assertThat(state.isTouching).isFalse()
+        assertThat(state.touchDownCornerIndex).isEqualTo(-1)
+        assertThat(state.touchDownEdgeIndex).isEqualTo(-1)
+        assertThat(state.dragPosition).isEqualTo(pos)   // preserved for loupe fade-out
+        assertThat(state.isDragging()).isFalse()
+    }
+
+    @Test
+    fun dragCycle_corner_leavesStateConsistent() {
+        val state = EditPageScreenState()
+        state.setInitialQuad(testQuad)
+        val pos = Offset(100f, 200f)
+
+        state.onTouchDown(pos, cornerIndex = 1)
+        state.startCornerDrag(1)
+        assertThat(state.isDragging()).isTrue()
+        assertThat(state.isTouching).isTrue()
+        assertThat(state.draggedCornerIndex).isEqualTo(1)
+        assertThat(state.touchDownCornerIndex).isEqualTo(1)
+
+        state.updateQuad(updatedQuad)
+        state.endDrag()
+        state.onTouchUp()
+
+        assertThat(state.isDragging()).isFalse()
+        assertThat(state.isTouching).isFalse()
+        assertThat(state.draggedCornerIndex).isEqualTo(-1)
+        assertThat(state.touchDownCornerIndex).isEqualTo(-1)
+        assertThat(state.touchDownEdgeIndex).isEqualTo(-1)
+        assertThat(state.dragPosition).isEqualTo(pos)   // preserved for loupe fade-out
+        assertThat(state.editableQuad).isEqualTo(updatedQuad)
+        assertThat(state.history.canUndo).isTrue()
+    }
+
+    @Test
+    fun dragCycle_edge_leavesStateConsistent() {
+        val state = EditPageScreenState()
+        state.setInitialQuad(testQuad)
+        val pos = Offset(150f, 80f)
+
+        state.onTouchDown(pos, edgeIndex = 0)
+        state.startEdgeDrag(0)
+        assertThat(state.isDragging()).isTrue()
+        assertThat(state.touchDownEdgeIndex).isEqualTo(0)
+
+        state.updateQuad(updatedQuad)
+        state.endDrag()
+        state.onTouchUp()
+
+        assertThat(state.isDragging()).isFalse()
+        assertThat(state.isTouching).isFalse()
+        assertThat(state.touchDownEdgeIndex).isEqualTo(-1)
+        assertThat(state.dragPosition).isEqualTo(pos)
+    }
+
+    @Test
+    fun consecutiveTaps_eachSetsCorrectTouchDownIndex() {
+        val state = EditPageScreenState()
+
+        state.onTouchDown(Offset(10f, 10f), cornerIndex = 0)
+        assertThat(state.touchDownCornerIndex).isEqualTo(0)
+        state.onTouchUp()
+
+        state.onTouchDown(Offset(90f, 10f), cornerIndex = 1)
+        assertThat(state.touchDownCornerIndex).isEqualTo(1)
+        state.onTouchUp()
+
+        state.onTouchDown(Offset(90f, 90f), cornerIndex = 2)
+        assertThat(state.touchDownCornerIndex).isEqualTo(2)
+        state.onTouchUp()
     }
 }

--- a/app/src/test/java/org/fairscan/app/ui/screens/edit/EditPageScreenStateTest.kt
+++ b/app/src/test/java/org/fairscan/app/ui/screens/edit/EditPageScreenStateTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 Philipp Hasper
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.fairscan.app.ui.screens.edit
+
+import org.assertj.core.api.Assertions.assertThat
+import org.fairscan.imageprocessing.Point
+import org.fairscan.imageprocessing.Quad
+import org.junit.Test
+
+class EditPageScreenStateTest {
+
+    private val testQuad = Quad(
+        topLeft = Point(0.1, 0.1),
+        topRight = Point(0.9, 0.1),
+        bottomRight = Point(0.9, 0.9),
+        bottomLeft = Point(0.1, 0.9)
+    )
+
+    private val updatedQuad = Quad(
+        topLeft = Point(0.2, 0.2),
+        topRight = Point(0.8, 0.2),
+        bottomRight = Point(0.8, 0.8),
+        bottomLeft = Point(0.2, 0.8)
+    )
+
+    @Test
+    fun initialState_hasCorrectDefaults() {
+        val state = EditPageScreenState()
+
+        assertThat(state.bitmap).isNull()
+        assertThat(state.containerSize).isNull()
+        assertThat(state.editableQuad).isNull()
+        assertThat(state.draggedCornerIndex).isEqualTo(-1)
+        assertThat(state.draggedEdgeIndex).isEqualTo(-1)
+        assertThat(state.isDragging()).isFalse()
+    }
+
+    @Test
+    fun quadUpdates_workCorrectly() {
+        val state = EditPageScreenState()
+
+        state.updateQuad(testQuad)
+        assertThat(state.editableQuad).isEqualTo(testQuad)
+
+        state.updateQuad(updatedQuad)
+        assertThat(state.editableQuad).isEqualTo(updatedQuad)
+    }
+
+    @Test
+    fun cornerAndEdgeDragging_managesStateCorrectly() {
+        val state = EditPageScreenState()
+
+        // Corner drag starts correctly
+        for (i in 0 until 4) {
+            state.startCornerDrag(i)
+            assertThat(state.draggedCornerIndex).isEqualTo(i)
+            assertThat(state.draggedEdgeIndex).isEqualTo(-1)
+            assertThat(state.isDragging()).isTrue()
+        }
+
+        // Edge drag starts correctly and resets corner
+        for (i in 0 until 4) {
+            state.startEdgeDrag(i)
+            assertThat(state.draggedEdgeIndex).isEqualTo(i)
+            assertThat(state.draggedCornerIndex).isEqualTo(-1)
+            assertThat(state.isDragging()).isTrue()
+        }
+
+        // Switching from corner to edge resets corner
+        state.startCornerDrag(0)
+        state.startEdgeDrag(2)
+        assertThat(state.draggedCornerIndex).isEqualTo(-1)
+        assertThat(state.draggedEdgeIndex).isEqualTo(2)
+
+        // Switching from edge to corner resets edge
+        state.startEdgeDrag(2)
+        state.startCornerDrag(0)
+        assertThat(state.draggedEdgeIndex).isEqualTo(-1)
+        assertThat(state.draggedCornerIndex).isEqualTo(0)
+
+        // End drag resets all
+        state.startCornerDrag(2)
+        state.endDrag()
+        assertThat(state.draggedCornerIndex).isEqualTo(-1)
+        assertThat(state.draggedEdgeIndex).isEqualTo(-1)
+        assertThat(state.isDragging()).isFalse()
+
+        // End drag after edge drag
+        state.startEdgeDrag(1)
+        state.endDrag()
+        assertThat(state.isDragging()).isFalse()
+
+        // End drag when not dragging stays in non-dragging state
+        state.endDrag()
+        assertThat(state.isDragging()).isFalse()
+        assertThat(state.draggedCornerIndex).isEqualTo(-1)
+        assertThat(state.draggedEdgeIndex).isEqualTo(-1)
+    }
+
+    @Test
+    fun fullDragCycle_preservesQuadAfterDragEnds() {
+        val state = EditPageScreenState()
+
+        // Corner drag cycle
+        assertThat(state.isDragging()).isFalse()
+        state.startCornerDrag(1)
+        assertThat(state.isDragging()).isTrue()
+        state.updateQuad(updatedQuad)
+        assertThat(state.editableQuad).isEqualTo(updatedQuad)
+        assertThat(state.isDragging()).isTrue()
+        state.endDrag()
+        assertThat(state.isDragging()).isFalse()
+        assertThat(state.editableQuad).isEqualTo(updatedQuad)
+
+        // Edge drag cycle
+        state.startEdgeDrag(3)
+        assertThat(state.isDragging()).isTrue()
+        state.updateQuad(testQuad)
+        assertThat(state.editableQuad).isEqualTo(testQuad)
+        state.endDrag()
+        assertThat(state.isDragging()).isFalse()
+        assertThat(state.editableQuad).isEqualTo(testQuad)
+    }
+}

--- a/app/src/test/java/org/fairscan/app/ui/screens/edit/MagnifyingGlassTest.kt
+++ b/app/src/test/java/org/fairscan/app/ui/screens/edit/MagnifyingGlassTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 Philipp Hasper
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.fairscan.app.ui.screens.edit
+
+import androidx.compose.ui.geometry.Offset
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+/** Acceptable offset for float comparisons **/
+private val FLOAT_OFFSET = org.assertj.core.data.Offset.offset(0.0001f)
+
+class MagnifyingGlassTest {
+
+    private val configPx = LoupeLayoutConfig(
+        loupeRadius = 150f,
+        verticalOffset = 200f,
+        screenMargin = 20f,
+    )
+    private val containerWidth = 1080f
+
+    @Test
+    fun abovePlacement_whenPlentyOfRoomAbove() {
+        // Finger in the middle of the screen, plenty of room everywhere
+        val drag = Offset(540f, 800f)
+        val result = computeLoupeCenter(drag, configPx, containerWidth)
+
+        // Expected Y: 800 - 200 - 150 = 450
+        assertThat(result.y).isCloseTo(450f, FLOAT_OFFSET)
+        // X should stay centred on finger
+        assertThat(result.x).isCloseTo(540f, FLOAT_OFFSET)
+    }
+
+    @Test
+    fun abovePlacement_clampsXToLeftEdge() {
+        // Finger very close to the left edge
+        val drag = Offset(50f, 800f)
+        val result = computeLoupeCenter(drag, configPx, containerWidth)
+
+        // X should be clamped to screenMargin + loupeRadius = 20 + 150 = 170
+        assertThat(result.x).isCloseTo(170f, FLOAT_OFFSET)
+        // Still placed above
+        assertThat(result.y).isCloseTo(450f, FLOAT_OFFSET)
+    }
+
+    @Test
+    fun abovePlacement_clampsXToRightEdge() {
+        // Finger very close to the right edge
+        val drag = Offset(1060f, 800f)
+        val result = computeLoupeCenter(drag, configPx, containerWidth)
+
+        // X should be clamped to containerWidth - screenMargin - loupeRadius = 1080 - 20 - 150 = 910
+        assertThat(result.x).isCloseTo(910f, FLOAT_OFFSET)
+        // Still placed above
+        assertThat(result.y).isCloseTo(450f, FLOAT_OFFSET)
+    }
+
+    @Test
+    fun leftPlacement_whenNotEnoughRoomAbove() {
+        // Finger near the top: Y must be small enough that above placement fails
+        // above center Y = dragY - verticalOffset - loupeRadius
+        // condition: aboveCenterY - loupeRadius >= screenMargin
+        // => dragY - 200 - 150 - 150 >= 20 => dragY >= 520
+        // Use dragY = 300 (not enough room above)
+        // Finger at centre-X so there IS room to the left
+        val drag = Offset(540f, 300f)
+        val result = computeLoupeCenter(drag, configPx, containerWidth)
+
+        // Left center X = 540 - 200 - 150 = 190
+        // leftCenterX - loupeRadius = 190 - 150 = 40 >= 20 ✓
+        assertThat(result.x).isCloseTo(190f, FLOAT_OFFSET)
+        // Y should equal dragY (clamped, but 300 > screenMargin + loupeRadius = 170)
+        assertThat(result.y).isCloseTo(300f, FLOAT_OFFSET)
+    }
+
+    @Test
+    fun leftPlacement_clampsYToTopEdge() {
+        // Finger at very top and far right (no room above, room to left)
+        val drag = Offset(540f, 100f)
+        val result = computeLoupeCenter(drag, configPx, containerWidth)
+
+        // Left placement: X = 540 - 200 - 150 = 190 (room check: 190 - 150 = 40 >= 20 ✓)
+        assertThat(result.x).isCloseTo(190f, FLOAT_OFFSET)
+        // Y clamped to screenMargin + loupeRadius = 20 + 150 = 170
+        assertThat(result.y).isCloseTo(170f, FLOAT_OFFSET)
+    }
+
+    @Test
+    fun rightPlacement_whenNoRoomAboveOrLeft() {
+        // Finger near top-left corner: not enough room above AND not enough room on the left
+        // For left to fail: leftCenterX - loupeRadius < screenMargin
+        // leftCenterX = dragX - 200 - 150 = dragX - 350
+        // leftCenterX - 150 = dragX - 500 < 20 => dragX < 520
+        // Also not enough room above: dragY < 520
+        val drag = Offset(100f, 300f)
+        val result = computeLoupeCenter(drag, configPx, containerWidth)
+
+        // Right center X = 100 + 200 + 150 = 450
+        // Clamped: min(450, 1080 - 20 - 150) = min(450, 910) = 450
+        assertThat(result.x).isCloseTo(450f, FLOAT_OFFSET)
+        // Y should equal dragY (300 > 170)
+        assertThat(result.y).isCloseTo(300f, FLOAT_OFFSET)
+    }
+
+    @Test
+    fun rightPlacement_clampsXToRightEdge() {
+        // Use a narrow container to force right placement with X clamping
+        val narrowResult = computeLoupeCenter(
+            Offset(100f, 300f), configPx, 500f
+        )
+
+        // Right center X = 100 + 200 + 150 = 450
+        // Clamped: min(450, 500 - 20 - 150) = min(450, 330) = 330
+        assertThat(narrowResult.x).isCloseTo(330f, FLOAT_OFFSET)
+        assertThat(narrowResult.y).isCloseTo(300f, FLOAT_OFFSET)
+    }
+
+    @Test
+    fun rightPlacement_clampsYToTopEdge() {
+        // Finger at extreme top-left: Y very small, no room above/left -> right, Y clamped
+        val drag = Offset(50f, 50f)
+        val result = computeLoupeCenter(drag, configPx, containerWidth)
+
+        // above: 50 - 200 - 150 = -300, -300 - 150 = -450 < 20 ✗
+        // left: 50 - 200 - 150 = -300, -300 - 150 = -450 < 20 ✗
+        // right: 50 + 200 + 150 = 400
+        assertThat(result.x).isCloseTo(400f, FLOAT_OFFSET)
+        // Y clamped to screenMargin + loupeRadius = 170
+        assertThat(result.y).isCloseTo(170f, FLOAT_OFFSET)
+    }
+
+    @Test
+    fun abovePlacement_exactBoundary() {
+        // dragY such that aboveCenterY - loupeRadius == screenMargin exactly
+        // dragY - verticalOffset - loupeRadius - loupeRadius = screenMargin
+        // dragY = screenMargin + 2*loupeRadius + verticalOffset = 20 + 300 + 200 = 520
+        val drag = Offset(540f, 520f)
+        val result = computeLoupeCenter(drag, configPx, containerWidth)
+
+        // Should still place above (condition uses >=)
+        val expectedY = 520f - 200f - 150f  // = 170
+        assertThat(result.y).isCloseTo(expectedY, FLOAT_OFFSET)
+        assertThat(result.x).isCloseTo(540f, FLOAT_OFFSET)
+    }
+}

--- a/app/src/test/java/org/fairscan/app/ui/screens/edit/QuadCoordinateUtilsTest.kt
+++ b/app/src/test/java/org/fairscan/app/ui/screens/edit/QuadCoordinateUtilsTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Philipp Hasper
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.fairscan.app.ui.screens.edit
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntSize
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset as AssertJOffset
+import org.fairscan.imageprocessing.Point
+import org.junit.Test
+
+class QuadCoordinateUtilsTest {
+
+    @Test
+    fun calculateDisplaySize_scalesCorrectlyForVariousAspectRatios() {
+        // Wider image than container - fits to width
+        var result = QuadCoordinateUtils.calculateDisplaySize(1920, 1080, IntSize(1000, 800))
+        assertThat(result.width).isEqualTo(1000)
+        assertThat(result.height).isCloseTo(562, AssertJOffset.offset(1))
+
+        // Taller image than container - fits to height
+        result = QuadCoordinateUtils.calculateDisplaySize(1080, 1920, IntSize(1000, 800))
+        assertThat(result.height).isEqualTo(800)
+        assertThat(result.width).isCloseTo(450, AssertJOffset.offset(1))
+
+        // Square image in square container
+        result = QuadCoordinateUtils.calculateDisplaySize(500, 500, IntSize(1000, 1000))
+        assertThat(result.width).isEqualTo(1000)
+        assertThat(result.height).isEqualTo(1000)
+
+        // Same aspect ratio - fills container
+        result = QuadCoordinateUtils.calculateDisplaySize(800, 600, IntSize(400, 300))
+        assertThat(result.width).isEqualTo(400)
+        assertThat(result.height).isEqualTo(300)
+    }
+
+    @Test
+    fun normalizedToScreen_convertsPointsWithCorrectOffset() {
+        val containerSize = IntSize(1000, 800)
+        val displaySize = IntSize(800, 600)
+        // Offset: (1000-800)/2 = 100 for x, (800-600)/2 = 100 for y
+
+        // Top-left corner (0,0)
+        var result = QuadCoordinateUtils.normalizedToScreen(Point(0.0, 0.0), containerSize, displaySize)
+        assertThat(result.x).isCloseTo(100f, AssertJOffset.offset(0.1f))
+        assertThat(result.y).isCloseTo(100f, AssertJOffset.offset(0.1f))
+
+        // Center (0.5, 0.5) -> x: 0.5*800+100=500, y: 0.5*600+100=400
+        result = QuadCoordinateUtils.normalizedToScreen(Point(0.5, 0.5), containerSize, displaySize)
+        assertThat(result.x).isCloseTo(500f, AssertJOffset.offset(0.1f))
+        assertThat(result.y).isCloseTo(400f, AssertJOffset.offset(0.1f))
+
+        // Bottom-right corner (1,1) -> x: 1.0*800+100=900, y: 1.0*600+100=700
+        result = QuadCoordinateUtils.normalizedToScreen(Point(1.0, 1.0), containerSize, displaySize)
+        assertThat(result.x).isCloseTo(900f, AssertJOffset.offset(0.1f))
+        assertThat(result.y).isCloseTo(700f, AssertJOffset.offset(0.1f))
+
+        // No offset when sizes match
+        result = QuadCoordinateUtils.normalizedToScreen(Point(0.0, 0.0), IntSize(800, 600), IntSize(800, 600))
+        assertThat(result.x).isCloseTo(0f, AssertJOffset.offset(0.1f))
+        assertThat(result.y).isCloseTo(0f, AssertJOffset.offset(0.1f))
+    }
+
+    @Test
+    fun screenDeltaToNormalized_convertsDeltas() {
+        val displaySize = IntSize(800, 600)
+
+        // Positive delta: 80/800=0.1, 60/600=0.1
+        var result = QuadCoordinateUtils.screenDeltaToNormalized(Offset(80f, 60f), displaySize)
+        assertThat(result.x).isCloseTo(0.1f, AssertJOffset.offset(0.001f))
+        assertThat(result.y).isCloseTo(0.1f, AssertJOffset.offset(0.001f))
+
+        // Zero delta
+        result = QuadCoordinateUtils.screenDeltaToNormalized(Offset(0f, 0f), displaySize)
+        assertThat(result.x).isEqualTo(0f)
+        assertThat(result.y).isEqualTo(0f)
+
+        // Negative delta: -160/800=-0.2, -120/600=-0.2
+        result = QuadCoordinateUtils.screenDeltaToNormalized(Offset(-160f, -120f), displaySize)
+        assertThat(result.x).isCloseTo(-0.2f, AssertJOffset.offset(0.001f))
+        assertThat(result.y).isCloseTo(-0.2f, AssertJOffset.offset(0.001f))
+    }
+
+    @Test
+    fun getImageOffset_calculatesCorrectOffsets() {
+        // Standard offset
+        var result = QuadCoordinateUtils.getImageOffset(IntSize(1000, 800), IntSize(800, 600))
+        assertThat(result.width).isEqualTo(100)
+        assertThat(result.height).isEqualTo(100)
+
+        // Same size - zero offset
+        result = QuadCoordinateUtils.getImageOffset(IntSize(800, 600), IntSize(800, 600))
+        assertThat(result.width).isEqualTo(0)
+        assertThat(result.height).isEqualTo(0)
+
+        // Asymmetric offset (only horizontal)
+        result = QuadCoordinateUtils.getImageOffset(IntSize(1000, 600), IntSize(800, 600))
+        assertThat(result.width).isEqualTo(100)
+        assertThat(result.height).isEqualTo(0)
+    }
+}

--- a/app/src/test/java/org/fairscan/app/ui/screens/edit/QuadEditingHandlerTest.kt
+++ b/app/src/test/java/org/fairscan/app/ui/screens/edit/QuadEditingHandlerTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 Philipp Hasper
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.fairscan.app.ui.screens.edit
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntSize
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset as AssertJOffset
+import org.fairscan.imageprocessing.Point
+import org.fairscan.imageprocessing.Quad
+import org.junit.Before
+import org.junit.Test
+
+class QuadEditingHandlerTest {
+
+    private lateinit var handler: QuadEditingHandler
+    private val containerSize = IntSize(1000, 800)
+    private val displaySize = IntSize(800, 600)
+
+    private val centeredQuad = Quad(
+        topLeft = Point(0.2, 0.2),
+        topRight = Point(0.8, 0.2),
+        bottomRight = Point(0.8, 0.8),
+        bottomLeft = Point(0.2, 0.8)
+    )
+
+    @Before
+    fun setUp() {
+        handler = QuadEditingHandler()
+    }
+
+    @Test
+    fun findTouchedCorner_detectsAllCornersAndMisses() {
+        // All four corners should be detected
+        val corners = listOf(centeredQuad.topLeft, centeredQuad.topRight, centeredQuad.bottomRight, centeredQuad.bottomLeft)
+        corners.forEachIndexed { index, corner ->
+            val touchPos = QuadCoordinateUtils.normalizedToScreen(corner, containerSize, displaySize)
+            assertThat(handler.findTouchedCorner(touchPos, centeredQuad, containerSize, displaySize)).isEqualTo(index)
+        }
+
+        // Near corner (within radius) should also be detected
+        val topLeftScreen = QuadCoordinateUtils.normalizedToScreen(centeredQuad.topLeft, containerSize, displaySize)
+        val nearTouch = Offset(topLeftScreen.x + 20f, topLeftScreen.y + 15f)
+        assertThat(handler.findTouchedCorner(nearTouch, centeredQuad, containerSize, displaySize)).isEqualTo(0)
+
+        // Far from corners should return -1
+        val centerTouch = QuadCoordinateUtils.normalizedToScreen(Point(0.5, 0.5), containerSize, displaySize)
+        assertThat(handler.findTouchedCorner(centerTouch, centeredQuad, containerSize, displaySize)).isEqualTo(-1)
+    }
+
+    @Test
+    fun findTouchedEdge_detectsAllEdgesAndMisses() {
+        // Test all four edge midpoints
+        val edgeMidpoints = listOf(
+            Point((centeredQuad.topLeft.x + centeredQuad.topRight.x) / 2, centeredQuad.topLeft.y),
+            Point(centeredQuad.topRight.x, (centeredQuad.topRight.y + centeredQuad.bottomRight.y) / 2),
+            Point((centeredQuad.bottomRight.x + centeredQuad.bottomLeft.x) / 2, centeredQuad.bottomRight.y),
+            Point(centeredQuad.topLeft.x, (centeredQuad.bottomLeft.y + centeredQuad.topLeft.y) / 2)
+        )
+        edgeMidpoints.forEachIndexed { index, midpoint ->
+            val touchPos = QuadCoordinateUtils.normalizedToScreen(midpoint, containerSize, displaySize)
+            assertThat(handler.findTouchedEdge(touchPos, centeredQuad, containerSize, displaySize)).isEqualTo(index)
+        }
+
+        // Far from edges should return -1
+        assertThat(handler.findTouchedEdge(Offset(10f, 10f), centeredQuad, containerSize, displaySize)).isEqualTo(-1)
+    }
+
+    @Test
+    fun updateQuadCorner_movesCorrectCornerAndClampsTooBounds() {
+        // Move each corner and verify only that corner changes
+        val deltas = listOf(Offset(0.1f, 0.1f), Offset(-0.1f, 0.1f), Offset(-0.1f, -0.1f), Offset(0.1f, -0.1f))
+        val expectedPositions = listOf(Point(0.3, 0.3), Point(0.7, 0.3), Point(0.7, 0.7), Point(0.3, 0.7))
+
+        deltas.forEachIndexed { index, delta ->
+            val result = handler.updateQuadCorner(centeredQuad, index, delta)
+            val movedCorner = when (index) {
+                0 -> result.topLeft
+                1 -> result.topRight
+                2 -> result.bottomRight
+                else -> result.bottomLeft
+            }
+            assertThat(movedCorner.x).isCloseTo(expectedPositions[index].x, AssertJOffset.offset(0.001))
+            assertThat(movedCorner.y).isCloseTo(expectedPositions[index].y, AssertJOffset.offset(0.001))
+        }
+
+        // Invalid index returns unchanged quad
+        assertThat(handler.updateQuadCorner(centeredQuad, 5, Offset(0.1f, 0.1f))).isEqualTo(centeredQuad)
+
+        // Zero delta returns unchanged quad
+        assertThat(handler.updateQuadCorner(centeredQuad, 0, Offset(0f, 0f))).isEqualTo(centeredQuad)
+
+        // Clamping to min bounds (0)
+        var result = handler.updateQuadCorner(centeredQuad, 0, Offset(-0.5f, -0.5f))
+        assertThat(result.topLeft.x).isEqualTo(0.0)
+        assertThat(result.topLeft.y).isEqualTo(0.0)
+
+        // Clamping to max bounds (1)
+        result = handler.updateQuadCorner(centeredQuad, 2, Offset(0.5f, 0.5f))
+        assertThat(result.bottomRight.x).isEqualTo(1.0)
+        assertThat(result.bottomRight.y).isEqualTo(1.0)
+    }
+
+    @Test
+    fun updateQuadEdge_movesBothCornersOfEdgeAndClamps() {
+        // Top edge (index 0) - moves topLeft and topRight
+        var result = handler.updateQuadEdge(centeredQuad, 0, Offset(0.0f, 0.1f))
+        assertThat(result.topLeft.y).isCloseTo(0.3, AssertJOffset.offset(0.001))
+        assertThat(result.topRight.y).isCloseTo(0.3, AssertJOffset.offset(0.001))
+        assertThat(result.bottomRight).isEqualTo(centeredQuad.bottomRight)
+        assertThat(result.bottomLeft).isEqualTo(centeredQuad.bottomLeft)
+
+        // Right edge (index 1) - moves topRight and bottomRight
+        result = handler.updateQuadEdge(centeredQuad, 1, Offset(-0.1f, 0.0f))
+        assertThat(result.topRight.x).isCloseTo(0.7, AssertJOffset.offset(0.001))
+        assertThat(result.bottomRight.x).isCloseTo(0.7, AssertJOffset.offset(0.001))
+        assertThat(result.topLeft).isEqualTo(centeredQuad.topLeft)
+        assertThat(result.bottomLeft).isEqualTo(centeredQuad.bottomLeft)
+
+        // Bottom edge (index 2) - moves bottomRight and bottomLeft
+        result = handler.updateQuadEdge(centeredQuad, 2, Offset(0.0f, -0.1f))
+        assertThat(result.bottomRight.y).isCloseTo(0.7, AssertJOffset.offset(0.001))
+        assertThat(result.bottomLeft.y).isCloseTo(0.7, AssertJOffset.offset(0.001))
+        assertThat(result.topLeft).isEqualTo(centeredQuad.topLeft)
+        assertThat(result.topRight).isEqualTo(centeredQuad.topRight)
+
+        // Left edge (index 3) - moves topLeft and bottomLeft
+        result = handler.updateQuadEdge(centeredQuad, 3, Offset(0.1f, 0.0f))
+        assertThat(result.topLeft.x).isCloseTo(0.3, AssertJOffset.offset(0.001))
+        assertThat(result.bottomLeft.x).isCloseTo(0.3, AssertJOffset.offset(0.001))
+        assertThat(result.topRight).isEqualTo(centeredQuad.topRight)
+        assertThat(result.bottomRight).isEqualTo(centeredQuad.bottomRight)
+
+        // Invalid index returns unchanged quad
+        assertThat(handler.updateQuadEdge(centeredQuad, 5, Offset(0.1f, 0.1f))).isEqualTo(centeredQuad)
+
+        // Zero delta returns unchanged quad
+        assertThat(handler.updateQuadEdge(centeredQuad, 0, Offset(0f, 0f))).isEqualTo(centeredQuad)
+    }
+
+    @Test
+    fun updateQuadEdge_clampsToImageBounds() {
+        // Clamp to min bounds
+        var result = handler.updateQuadEdge(centeredQuad, 0, Offset(-0.5f, -0.5f))
+        assertThat(result.topLeft.x).isEqualTo(0.0)
+        assertThat(result.topLeft.y).isEqualTo(0.0)
+        assertThat(result.topRight.y).isEqualTo(0.0)
+
+        // Clamp to max bounds
+        result = handler.updateQuadEdge(centeredQuad, 2, Offset(0.5f, 0.5f))
+        assertThat(result.bottomRight.x).isEqualTo(1.0)
+        assertThat(result.bottomRight.y).isEqualTo(1.0)
+        assertThat(result.bottomLeft.y).isEqualTo(1.0)
+    }
+}

--- a/app/src/test/java/org/fairscan/app/ui/screens/edit/QuadEditingHandlerTest.kt
+++ b/app/src/test/java/org/fairscan/app/ui/screens/edit/QuadEditingHandlerTest.kt
@@ -164,4 +164,87 @@ class QuadEditingHandlerTest {
         assertThat(result.bottomRight.y).isEqualTo(1.0)
         assertThat(result.bottomLeft.y).isEqualTo(1.0)
     }
+
+    // ── Convexity enforcement tests ──────────────────────────────────────
+
+    @Test
+    fun updateQuadCorner_rejectsConcaveResult() {
+        // Drag the topLeft corner past the diagonal to create a concave quad.
+        // Moving topLeft far to the right and down should make the quad concave.
+        val result = handler.updateQuadCorner(centeredQuad, 0, Offset(0.7f, 0.7f))
+        // The result should still be convex, meaning the move was rejected
+        // (the original quad is returned).
+        assertThat(result).isEqualTo(centeredQuad)
+    }
+
+    @Test
+    fun updateQuadCorner_allowsConvexResult() {
+        // A small move that keeps the quad convex should be allowed.
+        val result = handler.updateQuadCorner(centeredQuad, 0, Offset(0.05f, 0.05f))
+        // The corner should have moved.
+        assertThat(result.topLeft.x).isCloseTo(0.25, AssertJOffset.offset(0.001))
+        assertThat(result.topLeft.y).isCloseTo(0.25, AssertJOffset.offset(0.001))
+    }
+
+    @Test
+    fun updateQuadEdge_rejectsConcaveResult() {
+        // Drag the top edge far down, past the bottom edge.
+        val result = handler.updateQuadEdge(centeredQuad, 0, Offset(0.0f, 0.7f))
+        // The result should still be convex, meaning the move was rejected.
+        assertThat(result).isEqualTo(centeredQuad)
+    }
+
+    @Test
+    fun updateQuadEdge_allowsConvexResult() {
+        // A small move that keeps the quad convex should be allowed.
+        val result = handler.updateQuadEdge(centeredQuad, 0, Offset(0.0f, 0.05f))
+        assertThat(result.topLeft.y).isCloseTo(0.25, AssertJOffset.offset(0.001))
+        assertThat(result.topRight.y).isCloseTo(0.25, AssertJOffset.offset(0.001))
+    }
+
+    @Test
+    fun updateQuadCorner_allowsFixingConcaveQuad() {
+        // Start with a concave quad (topLeft is pushed too far inward).
+        val concaveQuad = Quad(
+            topLeft = Point(0.7, 0.7),  // past the center, making it concave
+            topRight = Point(0.8, 0.2),
+            bottomRight = Point(0.8, 0.8),
+            bottomLeft = Point(0.2, 0.8)
+        )
+        // Move topLeft back outward to restore convexity.
+        val result = handler.updateQuadCorner(concaveQuad, 0, Offset(-0.5f, -0.5f))
+        // The move should be allowed because the result is convex.
+        assertThat(result.topLeft.x).isCloseTo(0.2, AssertJOffset.offset(0.001))
+        assertThat(result.topLeft.y).isCloseTo(0.2, AssertJOffset.offset(0.001))
+    }
+
+    @Test
+    fun updateQuadEdge_allowsFixingConcaveQuad() {
+        // Start with a concave quad where the top edge is pushed past the bottom.
+        val concaveQuad = Quad(
+            topLeft = Point(0.2, 0.9),  // top edge below bottom edge
+            topRight = Point(0.8, 0.9),
+            bottomRight = Point(0.8, 0.8),
+            bottomLeft = Point(0.2, 0.8)
+        )
+        // Move the top edge back up to restore convexity.
+        val result = handler.updateQuadEdge(concaveQuad, 0, Offset(0.0f, -0.7f))
+        // The result should be convex and the move should be accepted.
+        assertThat(result.topLeft.y).isCloseTo(0.2, AssertJOffset.offset(0.001))
+        assertThat(result.topRight.y).isCloseTo(0.2, AssertJOffset.offset(0.001))
+    }
+
+    @Test
+    fun updateQuadCorner_rejectsMoveAlongEdgeThatCreatesConcavity() {
+        // Start with a nearly-flat quad that's still convex.
+        val narrowQuad = Quad(
+            topLeft = Point(0.2, 0.2),
+            topRight = Point(0.8, 0.2),
+            bottomRight = Point(0.8, 0.3),
+            bottomLeft = Point(0.2, 0.3)
+        )
+        // Drag bottomLeft upward past the top edge — should be rejected.
+        val result = handler.updateQuadCorner(narrowQuad, 3, Offset(0.0f, -0.2f))
+        assertThat(result).isEqualTo(narrowQuad)
+    }
 }

--- a/imageprocessing/src/main/java/org/fairscan/imageprocessing/Geometry.kt
+++ b/imageprocessing/src/main/java/org/fairscan/imageprocessing/Geometry.kt
@@ -47,6 +47,26 @@ data class Quad(
             Line(bottomLeft, topLeft))
     }
 
+    /**
+     * Returns `true` when the four corners form a strictly convex polygon with
+     * correct winding order (topLeft -> topRight -> bottomRight -> bottomLeft
+     * clockwise in screen coordinates where y increases downward).
+     *
+     * The check computes the cross product at each corner of consecutive edges
+     * and verifies that all four cross products are strictly positive.
+     */
+    fun isConvex(): Boolean {
+        val pts = listOf(topLeft, topRight, bottomRight, bottomLeft)
+        for (i in pts.indices) {
+            val a = pts[i]
+            val b = pts[(i + 1) % 4]
+            val c = pts[(i + 2) % 4]
+            val cross = (b.x - a.x) * (c.y - b.y) - (b.y - a.y) * (c.x - b.x)
+            if (cross <= 0.0) return false
+        }
+        return true
+    }
+
     fun rotate90(iterations: Int, imageSize: ImageSize): Quad {
         val rotatedPoints = listOf(
             rotate90(topLeft, imageSize, iterations),


### PR DESCRIPTION
This feature branch adds an optional quad-editing screen so users can make targeted corrections without abandoning the automation-first workflow.
The automatic quad detection is world-class, but users occasionally encounter problematic images - creased pages, atypical aspect ratio or cluttered backgrounds. Right now there is no way to recover from that.

The feature is **off by default** and is gated behind a setting. Nothing in the existing flow changes unless the user explicitly enables it. When enabled, a single new button appears on the DocumentScreen. This matches the project's philosophy of keeping the default experience fully automatic while giving power users an escape hatch.

There is also a concrete benefit for the intent-based **Nextcloud integration**: an intent extra lets the host app request the edit functionality temporarily. Nextcloud's built-in scanner exposes quad manipulation as a core feature. Matching that capability increases the chances of FairScan becoming the default scanning option there.

Tickets: #72, #59

## Features

- Move corners and edges of the quad.
- A loupe for precise placement, with visualization of the page border and a striped pattern for areas outside the page. The loupe disappears after lifting the finger with a short delay so you can confirm the final position.
- Undo/redo history for corner and edge movements. History is cleared when leaving the screen.
- "Report" button in the overflow menu to share problematic images with the maintainer.
- If the automatic page detection fails to find any document (and the feature toggle is ON), the page is stored as full image. This allows quad editing and also reporting these types of most problematic images to the maintainer.
- Supports user-defined page rotation.
- Supports landscape mode.
- An intent extra to enable the edit screen from a host app (relevant for the Nextcloud integration).

| <img width="auto" height="679" alt="portrait" src="https://github.com/user-attachments/assets/f241b253-5f05-4ae0-912f-f4cbf431e595" /> | <video src="https://github.com/user-attachments/assets/0ae707aa-f5b8-4c4e-adfa-2ef8971bbd3c" /> |
|----------------------|-------------------------------------------|
<img width="680" height="auto" alt="landscape" src="https://github.com/user-attachments/assets/47d08c3b-d7df-4dd4-8b9b-593a0d9b1c36" />

## Note 1: Merge conflicts

This branch is based on an older commit of main, so there are non-trivial merge conflicts with the current main branch. That is also why the screen is called EditPage and the setting is labelled "Enable manual image editing" - the intent was to keep it open for other manual edits such as color correction, which has since been added elsewhere. I would like to discuss the feature and general approach before investing the effort to resolve those conflicts and refactor the added code.

## Note 2: Button layout suggestion

The current feature branch is _purely additive_: the setting adds a button without rearranging anything. Now that the color-edit button from main is also there, it may be worth tidying up the row. This is a suggestion only and _not yet part of the current feature branch_. A possible direction:

**If the setting is OFF:**

1. Show only one rotation button (it already covers all rotations).
2. Show the color-edit button next to it with a more distinctive icon, e.g. `Icons.Default.ColorLens`.
<img width="292" height="207" alt="two buttons" src="https://github.com/user-attachments/assets/13bf3de1-6e37-4f2c-9aea-09048b27ff0d" />

**If the setting is ON:**

1. Show only one rotation button.
2. Show the color-edit button next to it.
3. Show the quad-edit button next to it with a descriptive icon, e.g. `Icons.Default.Crop`.
<img width="289" height="205" alt="three buttons" src="https://github.com/user-attachments/assets/da75c282-25d7-41e2-84da-005cb7edec97" />

## Note 3: AI Coding assistance
This contribution made use of Github Copilot