### PR TITLE
Avoid displaying the back button when back should be handled by the system

### DIFF
--- a/app/src/main/java/org/fairscan/app/MainActivity.kt
+++ b/app/src/main/java/org/fairscan/app/MainActivity.kt
@@ -486,6 +486,10 @@ class MainActivity : ComponentActivity() {
                 setResult(RESULT_CANCELED)
                 finish()
             }
+        },
+        shouldDisplayBackButton = {
+            viewModel.currentScreen.value !is Screen.Main.Camera
+                    || launchMode == LaunchMode.EXTERNAL_SCAN_TO_PDF
         }
     )
 }

--- a/app/src/main/java/org/fairscan/app/ui/Navigation.kt
+++ b/app/src/main/java/org/fairscan/app/ui/Navigation.kt
@@ -37,6 +37,7 @@ data class Navigation(
     val toLibrariesScreen: () -> Unit,
     val toSettingsScreen: (() -> Unit)?,
     val back: () -> Unit,
+    val shouldDisplayBackButton: () -> Boolean,
 )
 
 @ConsistentCopyVisibility

--- a/app/src/main/java/org/fairscan/app/ui/PreviewUtils.kt
+++ b/app/src/main/java/org/fairscan/app/ui/PreviewUtils.kt
@@ -25,7 +25,7 @@ import org.fairscan.app.ui.state.PageThumbnail
 import org.fairscan.imageprocessing.ColorMode
 
 fun dummyNavigation(): Navigation {
-    return Navigation({}, {}, {}, {}, {}, {}, {}, {})
+    return Navigation({}, {}, {}, {}, {}, {}, {}, {}, { -> true})
 }
 
 fun fakeDocument(pageIds: ImmutableList<String>, context: Context): DocumentUiModel {

--- a/app/src/main/java/org/fairscan/app/ui/components/Scaffold.kt
+++ b/app/src/main/java/org/fairscan/app/ui/components/Scaffold.kt
@@ -85,12 +85,14 @@ fun MyScaffold(
                 }
             }
         }
-        BackButton(
-            navigation.back,
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .windowInsetsPadding(WindowInsets.safeDrawing)
-        )
+        if (navigation.shouldDisplayBackButton()) {
+            BackButton(
+                navigation.back,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .windowInsetsPadding(WindowInsets.safeDrawing)
+            )
+        }
         AppOverflowMenu(
             navigation,
             modifier = Modifier


### PR DESCRIPTION
After removing the home screen, displaying the back button on the camera screen didn't make sense anymore.