### PR TITLE
Human-friendly file name when called through an intent

### DIFF
--- a/app/src/main/java/org/fairscan/app/ui/screens/export/ExportViewModel.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/export/ExportViewModel.kt
@@ -82,7 +82,12 @@ class ExportViewModel(container: AppContainer, val imageRepository: ImageReposit
     }
 
     suspend fun generatePdfForExternalCall(): ExportResult.Pdf {
-        return generatePdf(ExportQuality.BALANCED)
+        val pdf = generatePdf(ExportQuality.BALANCED)
+        val sourceFile = pdf.file
+        val targetFile = File(sourceFile.parentFile, defaultFilename() + ".pdf")
+        if (sourceFile.absolutePath == targetFile.absolutePath) return pdf
+        if (targetFile.exists() || !sourceFile.renameTo(targetFile)) return pdf
+        return pdf.copy(file = targetFile)
     }
 
     private val _uiState = MutableStateFlow(ExportUiState())


### PR DESCRIPTION
When called through an intent, FairScan currently generates a file with a timestamp-based name, for example `1774105774501.pdf`.

With the addition of `android.intent.action.GET_CONTENT` on `android.intent.category.OPENABLE` (see #137), apps such as Chrome and Firefox may now display the file name. FairScan should provide a human-friendly file name such as `Scan 2026-04-10 17.39.54.pdf`.

That doesn't change [the contract](https://github.com/pynicolas/FairScan#experimental-scan-to-pdf-via-intent) for `org.fairscan.app.action.SCAN_TO_PDF`.