### PR TITLE
Explicit choice on startup: resume current scan or start new

### DIFF
--- a/app/src/main/java/org/fairscan/app/MainActivity.kt
+++ b/app/src/main/java/org/fairscan/app/MainActivity.kt
@@ -57,7 +57,7 @@ import org.fairscan.app.ui.components.rememberCameraPermissionState
 import org.fairscan.app.ui.screens.document.DocumentScreen
 import org.fairscan.app.ui.screens.crop.CropScreen
 import org.fairscan.app.ui.screens.LibrariesScreen
-import org.fairscan.app.ui.screens.CurrentScanScreen
+import org.fairscan.app.ui.screens.ResumeScanScreen
 import org.fairscan.app.ui.screens.about.AboutEvent
 import org.fairscan.app.ui.screens.about.AboutScreen
 import org.fairscan.app.ui.screens.about.AboutViewModel
@@ -162,8 +162,8 @@ class MainActivity : ComponentActivity() {
                     null -> {
                         // waiting to load pages to get an initial screen
                     }
-                    is Screen.Main.CurrentScan -> {
-                        CurrentScanScreen(
+                    is Screen.Main.ResumeScan -> {
+                        ResumeScanScreen(
                             currentDocument = documentUiState,
                             onResumeScan = navigation.toCameraScreen,
                             onStartNewScan = {

--- a/app/src/main/java/org/fairscan/app/MainActivity.kt
+++ b/app/src/main/java/org/fairscan/app/MainActivity.kt
@@ -57,6 +57,7 @@ import org.fairscan.app.ui.components.rememberCameraPermissionState
 import org.fairscan.app.ui.screens.document.DocumentScreen
 import org.fairscan.app.ui.screens.crop.CropScreen
 import org.fairscan.app.ui.screens.LibrariesScreen
+import org.fairscan.app.ui.screens.CurrentScanScreen
 import org.fairscan.app.ui.screens.about.AboutEvent
 import org.fairscan.app.ui.screens.about.AboutScreen
 import org.fairscan.app.ui.screens.about.AboutViewModel
@@ -160,6 +161,16 @@ class MainActivity : ComponentActivity() {
                 when (currentScreen) {
                     null -> {
                         // waiting to load pages to get an initial screen
+                    }
+                    is Screen.Main.CurrentScan -> {
+                        CurrentScanScreen(
+                            currentDocument = documentUiState,
+                            onResumeScan = navigation.toCameraScreen,
+                            onStartNewScan = {
+                                viewModel.startNewDocument()
+                                navigation.toCameraScreen()
+                            }
+                        )
                     }
                     is Screen.Main.Camera -> {
                         val pickMultiple = rememberLauncherForActivityResult(

--- a/app/src/main/java/org/fairscan/app/MainViewModel.kt
+++ b/app/src/main/java/org/fairscan/app/MainViewModel.kt
@@ -73,7 +73,7 @@ class MainViewModel(val imageRepository: ImageRepository, logger: Logger): ViewM
                 if (pages.isEmpty()) {
                     NavigationState.initial()
                 } else {
-                    NavigationState.initial().navigateTo(Screen.Main.CurrentScan)
+                    NavigationState.initial().navigateTo(Screen.Main.ResumeScan)
                 }
         }
     }

--- a/app/src/main/java/org/fairscan/app/MainViewModel.kt
+++ b/app/src/main/java/org/fairscan/app/MainViewModel.kt
@@ -73,7 +73,7 @@ class MainViewModel(val imageRepository: ImageRepository, logger: Logger): ViewM
                 if (pages.isEmpty()) {
                     NavigationState.initial()
                 } else {
-                    NavigationState.initial().navigateTo(Screen.Main.Export)
+                    NavigationState.initial().navigateTo(Screen.Main.CurrentScan)
                 }
         }
     }

--- a/app/src/main/java/org/fairscan/app/ui/Navigation.kt
+++ b/app/src/main/java/org/fairscan/app/ui/Navigation.kt
@@ -20,7 +20,7 @@ sealed class Screen {
         object EditImage : Main()
         data class Document(val initialPage: Int = 0) : Main()
         object Export : Main()
-        object CurrentScan : Main()
+        object ResumeScan : Main()
     }
     sealed class Overlay : Screen() {
         object About : Overlay()
@@ -66,7 +66,7 @@ data class NavigationState private constructor(val stack: List<Screen>, val root
     fun navigateBack(): NavigationState {
         return when (current) {
             root -> this // Back handled by system
-            is Screen.Main.CurrentScan -> this // Back handled by system
+            is Screen.Main.ResumeScan -> this // Back handled by system
             is Screen.Main.Camera -> this // Back handled by system
             is Screen.Main.Document -> copy(stack = listOf(Screen.Main.Camera))
             is Screen.Main.EditImage -> copy(stack = listOf(Screen.Main.Document()))

--- a/app/src/main/java/org/fairscan/app/ui/Navigation.kt
+++ b/app/src/main/java/org/fairscan/app/ui/Navigation.kt
@@ -20,6 +20,7 @@ sealed class Screen {
         object EditImage : Main()
         data class Document(val initialPage: Int = 0) : Main()
         object Export : Main()
+        object CurrentScan : Main()
     }
     sealed class Overlay : Screen() {
         object About : Overlay()
@@ -65,6 +66,7 @@ data class NavigationState private constructor(val stack: List<Screen>, val root
     fun navigateBack(): NavigationState {
         return when (current) {
             root -> this // Back handled by system
+            is Screen.Main.CurrentScan -> this // Back handled by system
             is Screen.Main.Camera -> this // Back handled by system
             is Screen.Main.Document -> copy(stack = listOf(Screen.Main.Camera))
             is Screen.Main.EditImage -> copy(stack = listOf(Screen.Main.Document()))

--- a/app/src/main/java/org/fairscan/app/ui/screens/CurrentScanScreen.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/CurrentScanScreen.kt
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2025-2026 The FairScan authors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.fairscan.app.ui.screens
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.toImmutableList
+import org.fairscan.app.R
+import org.fairscan.app.domain.PageViewKey
+import org.fairscan.app.domain.Rotation
+import org.fairscan.app.ui.components.isLandscape
+import org.fairscan.app.ui.components.pageCountText
+import org.fairscan.app.ui.fakeDocument
+import org.fairscan.app.ui.fakeImage
+import org.fairscan.app.ui.screens.document.CurrentPageUiState
+import org.fairscan.app.ui.screens.document.DocumentUiState
+import org.fairscan.app.ui.theme.FairScanTheme
+import org.fairscan.imageprocessing.ColorMode
+
+
+@Composable
+fun CurrentScanScreen(
+    currentDocument: DocumentUiState,
+    onResumeScan: () -> Unit,
+    onStartNewScan: () -> Unit,
+) {
+    val pageCount = currentDocument.document.pageCount()
+    val firstPageThumbnail = currentDocument.currentPage?.bitmap
+
+    val resumeScanModifier = Modifier
+        .fillMaxWidth()
+        .clickable(onClick = onResumeScan)
+        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f))
+        .padding(horizontal = 16.dp, vertical = 24.dp)
+
+    Scaffold { innerPadding ->
+        if (!isLandscape(LocalConfiguration.current)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+            ) {
+                Column(
+                    modifier = resumeScanModifier.weight(2f),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    FirstPageThumbnail(firstPageThumbnail, Modifier.weight(1f))
+                    Spacer(modifier = Modifier.height(20.dp))
+                    ResumeScanActions(pageCount, onResumeScan)
+                }
+                HorizontalDivider()
+                NewScanArea(onStartNewScan, Modifier.weight(1f))
+            }
+        } else {
+            Row {
+                Row(
+                    modifier = resumeScanModifier.weight(1.8f),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    FirstPageThumbnail(firstPageThumbnail, Modifier.weight(1f))
+                    Spacer(Modifier.width(8.dp))
+                    Column(
+                        verticalArrangement = Arrangement.Center,
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight(),
+                    ) {
+                        ResumeScanActions(pageCount, onResumeScan)
+                    }
+                }
+                VerticalDivider()
+                NewScanArea(onStartNewScan, Modifier.weight(1f))
+            }
+        }
+    }
+}
+@Composable
+private fun FirstPageThumbnail(firstPageThumbnail: Bitmap?, modifier: Modifier) {
+    firstPageThumbnail?.let { bmp ->
+        Box(
+            modifier = modifier,
+            contentAlignment = Alignment.Center,
+        ) {
+            Image(
+                bitmap = bmp.asImageBitmap(),
+                contentDescription = null,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(8.dp))
+                    .border(1.dp, Color.Gray, RoundedCornerShape(8.dp)),
+                contentScale = ContentScale.Fit,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ResumeScanActions(pageCount: Int, onResumeScan: () -> Unit) {
+    Row {
+        Text(stringResource(R.string.scan_current))
+        Text(" • ")
+        Text(pageCountText(pageCount))
+    }
+    BigButton(onClick = onResumeScan, text = stringResource(R.string.scan_resume))
+}
+
+@Composable
+private fun NewScanArea(onStartNewScan: () -> Unit, modifier: Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .clickable(onClick = onStartNewScan)
+            .padding(horizontal = 16.dp, vertical = 32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(R.string.scan_discard_current),
+            textAlign = TextAlign.Center,
+        )
+        BigButton(onClick = onStartNewScan, text = stringResource(R.string.scan_start_new))
+    }
+}
+
+@Composable
+fun BigButton(onClick: () -> Unit, text: String) {
+    Button(onClick = onClick, modifier = Modifier.padding(vertical = 16.dp)) {
+        Text(
+            text,
+            style = MaterialTheme.typography.titleLarge,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(vertical = 4.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Preview(showBackground = true, widthDp = 320, heightDp = 640)
+@Preview(showBackground = true, widthDp = 640, heightDp = 320)
+@Composable
+fun CurrentScanScreenPreview() {
+    val image = fakeImage("gallica.bnf.fr-bpt6k5530456s-1", LocalContext.current).toBitmap()
+    val document = fakeDocument(
+        listOf(1, 2).map { "gallica.bnf.fr-bpt6k5530456s-$it" }.toImmutableList(),
+        LocalContext.current
+    )
+    val key = PageViewKey("123", Rotation.R0, null, 0)
+    FairScanTheme {
+        CurrentScanScreen(
+            DocumentUiState(1, CurrentPageUiState(key,image, ColorMode.COLOR, true), document),
+             {}, {}
+        )
+    }
+}

--- a/app/src/main/java/org/fairscan/app/ui/screens/ResumeScanScreen.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/ResumeScanScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -144,10 +145,12 @@ private fun FirstPageThumbnail(firstPageThumbnail: Bitmap?, modifier: Modifier) 
 
 @Composable
 private fun ResumeScanActions(pageCount: Int, onResumeScan: () -> Unit) {
-    Row {
-        Text(stringResource(R.string.scan_current))
-        Text(" • ")
-        Text(pageCountText(pageCount))
+
+    FlowRow {
+        val style = MaterialTheme.typography.bodyMedium
+        Text(stringResource(R.string.scan_current), style = style)
+        Text(" • ", style = style)
+        Text(pageCountText(pageCount), style = style)
     }
     BigButton(onClick = onResumeScan, text = stringResource(R.string.scan_resume))
 }
@@ -165,6 +168,7 @@ private fun NewScanArea(onStartNewScan: () -> Unit, modifier: Modifier) {
         Text(
             text = stringResource(R.string.scan_discard_current),
             textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyMedium,
         )
         BigButton(onClick = onStartNewScan, text = stringResource(R.string.scan_start_new))
     }

--- a/app/src/main/java/org/fairscan/app/ui/screens/ResumeScanScreen.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/ResumeScanScreen.kt
@@ -65,7 +65,7 @@ import org.fairscan.imageprocessing.ColorMode
 
 
 @Composable
-fun CurrentScanScreen(
+fun ResumeScanScreen(
     currentDocument: DocumentUiState,
     onResumeScan: () -> Unit,
     onStartNewScan: () -> Unit,
@@ -186,7 +186,7 @@ fun BigButton(onClick: () -> Unit, text: String) {
 @Preview(showBackground = true, widthDp = 320, heightDp = 640)
 @Preview(showBackground = true, widthDp = 640, heightDp = 320)
 @Composable
-fun CurrentScanScreenPreview() {
+fun ResumeScanScreenPreview() {
     val image = fakeImage("gallica.bnf.fr-bpt6k5530456s-1", LocalContext.current).toBitmap()
     val document = fakeDocument(
         listOf(1, 2).map { "gallica.bnf.fr-bpt6k5530456s-$it" }.toImmutableList(),
@@ -194,7 +194,7 @@ fun CurrentScanScreenPreview() {
     )
     val key = PageViewKey("123", Rotation.R0, null, 0)
     FairScanTheme {
-        CurrentScanScreen(
+        ResumeScanScreen(
             DocumentUiState(1, CurrentPageUiState(key,image, ColorMode.COLOR, true), document),
              {}, {}
         )

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -58,6 +58,10 @@
     <string name="rotate_right">تدوير إلى اليمين</string>
     <string name="save">احفظ</string>
     <string name="scan_button">مسح جديد</string>
+    <string name="scan_current">المسح الحالي</string>
+    <string name="scan_discard_current">تجاهل المسح الحالي</string>
+    <string name="scan_resume">متابعة المسح</string>
+    <string name="scan_start_new">بدء مسح جديد</string>
     <string name="settings">الإعدادات</string>
     <string name="settings_ocr_download_error">فشل التنزيل. تحقق من اتصالك بالإنترنت.</string>
     <string name="settings_ocr_download_intro">يتم تنزيل ملفات اللغة من مشروع Tesseract الرسمي. تبقى عملية التعرّف على النصوص دون اتصال بالإنترنت بالكامل.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -58,6 +58,10 @@
     <string name="rotate_right">Otočit doprava</string>
     <string name="save">Uložit</string>
     <string name="scan_button">Nové skenování</string>
+    <string name="scan_current">Aktuální sken</string>
+    <string name="scan_discard_current">Zahodit aktuální sken</string>
+    <string name="scan_resume">Pokračovat ve skenování</string>
+    <string name="scan_start_new">Nový sken</string>
     <string name="settings">Nastavení</string>
     <string name="settings_ocr_download_error">Stahování se nezdařilo. Zkontrolujte své internetové připojení.</string>
     <string name="settings_ocr_download_intro">Jazykové soubory jsou stahovány z oficiálního projektu Tesseract. Rozpoznávání textu zůstává zcela offline.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -58,6 +58,10 @@
     <string name="rotate_right">Nach rechts drehen</string>
     <string name="save">Speichern</string>
     <string name="scan_button">Neuer Scan</string>
+    <string name="scan_current">Aktueller Scan</string>
+    <string name="scan_discard_current">Aktuellen Scan verwerfen</string>
+    <string name="scan_resume">Scan fortsetzen</string>
+    <string name="scan_start_new">Neuen Scan starten</string>
     <string name="settings">Einstellungen</string>
     <string name="settings_ocr_download_error">Download fehlgeschlagen. Überprüfen Sie Ihre Internetverbindung.</string>
     <string name="settings_ocr_download_intro">Sprachdateien werden vom offiziellen Tesseract-Projekt heruntergeladen. Die Texterkennung bleibt vollständig offline.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -58,6 +58,10 @@
     <string name="rotate_right">Girar a la derecha</string>
     <string name="save">Guardar</string>
     <string name="scan_button">Nuevo escaneo</string>
+    <string name="scan_current">Escaneo actual</string>
+    <string name="scan_discard_current">Descartar el escaneo actual</string>
+    <string name="scan_resume">Reanudar escaneo</string>
+    <string name="scan_start_new">Iniciar nuevo escaneo</string>
     <string name="settings">Ajustes</string>
     <string name="settings_ocr_download_error">La descarga ha fallado. Comprueba tu conexión a Internet.</string>
     <string name="settings_ocr_download_intro">Los archivos de idioma se descargan desde el proyecto oficial Tesseract. El reconocimiento de texto sigue siendo completamente local.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -58,6 +58,10 @@
     <string name="rotate_right">Pivoter vers la droite</string>
     <string name="save">Enregistrer</string>
     <string name="scan_button">Nouveau scan</string>
+    <string name="scan_current">Scan en cours</string>
+    <string name="scan_discard_current">Abandonner le scan en cours</string>
+    <string name="scan_resume">Reprendre le scan</string>
+    <string name="scan_start_new">Nouveau scan</string>
     <string name="settings">Paramètres</string>
     <string name="settings_ocr_download_error">Le téléchargement a échoué. Vérifiez votre connexion Internet.</string>
     <string name="settings_ocr_download_intro">Les fichiers de langue sont téléchargés depuis le projet officiel Tesseract. La reconnaissance de texte reste entièrement hors ligne.</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -58,6 +58,10 @@
     <string name="rotate_right">Xirar á dereita</string>
     <string name="save">Gardar</string>
     <string name="scan_button">Novo escaneo</string>
+    <string name="scan_current">Escaneo actual</string>
+    <string name="scan_discard_current">Descartar o escaneo actual</string>
+    <string name="scan_resume">Retomar escaneo</string>
+    <string name="scan_start_new">Novo escaneo</string>
     <string name="settings">Configuración</string>
     <string name="settings_ocr_download_error">Produciuse un erro na descarga. Comproba a túa conexión á Internet.</string>
     <string name="settings_ocr_download_intro">Os ficheiros de idioma descárganse desde o proxecto oficial Tesseract. O recoñecemento de texto segue sendo completamente sen conexión.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -58,6 +58,10 @@
     <string name="rotate_right">Ruota a destra</string>
     <string name="save">Salva</string>
     <string name="scan_button">Nuova scansione</string>
+    <string name="scan_current">Scansione corrente</string>
+    <string name="scan_discard_current">Elimina la scansione corrente</string>
+    <string name="scan_resume">Riprendi scansione</string>
+    <string name="scan_start_new">Nuova scansione</string>
     <string name="settings">Impostazioni</string>
     <string name="settings_ocr_download_error">Download non riuscito. Controlla la connessione a Internet.</string>
     <string name="settings_ocr_download_intro">I file di lingua vengono scaricati dal progetto ufficiale Tesseract. Il riconoscimento del testo rimane completamente offline.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -58,6 +58,10 @@
     <string name="rotate_right">右に回転</string>
     <string name="save">保存</string>
     <string name="scan_button">新規スキャン</string>
+    <string name="scan_current">現在のスキャン</string>
+    <string name="scan_discard_current">現在のスキャンを破棄</string>
+    <string name="scan_resume">スキャンを再開</string>
+    <string name="scan_start_new">新しいスキャン</string>
     <string name="settings">設定</string>
     <string name="settings_ocr_download_error">ダウンロードに失敗しました。インターネット接続を確認してください。</string>
     <string name="settings_ocr_download_intro">言語ファイルは公式の Tesseract プロジェクトからダウンロードされます。テキスト認識は完全にオフラインで実行されます。</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -58,6 +58,10 @@
     <string name="rotate_right">Girar para a direita</string>
     <string name="save">Salvar</string>
     <string name="scan_button">Nova digitalização</string>
+    <string name="scan_current">Digitalização atual</string>
+    <string name="scan_discard_current">Descartar a digitalização atual</string>
+    <string name="scan_resume">Retomar digitalização</string>
+    <string name="scan_start_new">Nova digitalização</string>
     <string name="settings">Configurações</string>
     <string name="settings_ocr_download_error">Falha no download. Verifique sua conexão com a Internet.</string>
     <string name="settings_ocr_download_intro">Os arquivos de idioma são baixados do projeto oficial Tesseract. O reconhecimento de texto permanece totalmente offline.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -58,6 +58,10 @@
     <string name="rotate_right">Повернуть вправо</string>
     <string name="save">Сохранить</string>
     <string name="scan_button">Начать</string>
+    <string name="scan_current">Текущее сканирование</string>
+    <string name="scan_discard_current">Отменить текущее сканирование</string>
+    <string name="scan_resume">Продолжить сканирование</string>
+    <string name="scan_start_new">Новое сканирование</string>
     <string name="settings">Настройки</string>
     <string name="settings_ocr_download_error">Не удалось загрузить файл. Проверьте подключение к Интернету.</string>
     <string name="settings_ocr_download_intro">Языковые файлы загружаются из официального проекта Tesseract. Распознавание текста остаётся полностью офлайн.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -58,6 +58,10 @@
     <string name="rotate_right">Rotera åt höger</string>
     <string name="save">Spara</string>
     <string name="scan_button">Ny skanning</string>
+    <string name="scan_current">Aktuell skanning</string>
+    <string name="scan_discard_current">Kassera aktuell skanning</string>
+    <string name="scan_resume">Återuppta skanning</string>
+    <string name="scan_start_new">Ny skanning</string>
     <string name="settings">Inställningar</string>
     <string name="settings_ocr_download_error">Nedladdningen misslyckades. Kontrollera din internetanslutning.</string>
     <string name="settings_ocr_download_intro">Språkfiler hämtas från det officiella Tesseract-projektet. Textigenkänning förblir helt offline.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -58,6 +58,10 @@
     <string name="rotate_right">Sağa döndür</string>
     <string name="save">Kaydet</string>
     <string name="scan_button">Yeni Tarama</string>
+    <string name="scan_current">Geçerli tarama</string>
+    <string name="scan_discard_current">Geçerli taramayı sil</string>
+    <string name="scan_resume">Taramaya devam et</string>
+    <string name="scan_start_new">Yeni tarama</string>
     <string name="settings">Ayarlar</string>
     <string name="settings_ocr_download_error">İndirme başarısız oldu. İnternet bağlantınızı kontrol edin.</string>
     <string name="settings_ocr_download_intro">Dil dosyaları resmi Tesseract projesinden indirilir. Metin tanıma tamamen çevrimdışı olarak çalışır.</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -58,6 +58,10 @@
     <string name="rotate_right">向右旋轉</string>
     <string name="save">儲存</string>
     <string name="scan_button">開始掃描</string>
+    <string name="scan_current">目前掃描</string>
+    <string name="scan_discard_current">放棄目前掃描</string>
+    <string name="scan_resume">繼續掃描</string>
+    <string name="scan_start_new">新增掃描</string>
     <string name="settings">設定</string>
     <string name="settings_ocr_download_error">下載失敗。請檢查您的網路連線。</string>
     <string name="settings_ocr_download_intro">語言檔案會從官方 Tesseract 專案下載。文字辨識始終完全離線運作。</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -58,6 +58,10 @@
     <string name="rotate_right">向右旋转</string>
     <string name="save">保存</string>
     <string name="scan_button">新建扫描</string>
+    <string name="scan_current">当前扫描</string>
+    <string name="scan_discard_current">放弃当前扫描</string>
+    <string name="scan_resume">继续扫描</string>
+    <string name="scan_start_new">新建扫描</string>
     <string name="settings">设置</string>
     <string name="settings_ocr_download_error">下载失败。请检查您的网络连接。</string>
     <string name="settings_ocr_download_intro">语言文件从官方 Tesseract 项目下载。文本识别始终完全离线运行。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,10 @@
     <string name="rotate_right">Rotate right</string>
     <string name="save">Save</string>
     <string name="scan_button">New Scan</string>
+    <string name="scan_current">Current scan</string>
+    <string name="scan_discard_current">Discard the current scan</string>
+    <string name="scan_resume">Resume scan</string>
+    <string name="scan_start_new">Start new scan</string>
     <string name="settings">Settings</string>
     <string name="settings_ocr_download_error">Download failed. Check your internet connection.</string>
     <string name="settings_ocr_download_intro">"Language files are downloaded from the official Tesseract project. Text recognition remains fully offline."</string>


### PR DESCRIPTION
It seems that some app concepts are unclear to some users (current scan, scan ≠ page, see #201). This is probably linked to the removal of the Home screen (#170) which also removed the explicit choice on startup when a current scan exists: either resume the current scan or start a new one. The explicit choice at least clarified the concept of current scan. This PR creates a new screen that is displayed only on startup when a current scan exists. When the user wants to start a new scan (probably the most common case), it takes one tap, exactly the same as currently.