### PR TITLE
Import photo: picker with a "Browse" option

### DIFF
--- a/app/src/main/java/org/fairscan/app/MainActivity.kt
+++ b/app/src/main/java/org/fairscan/app/MainActivity.kt
@@ -34,7 +34,6 @@ import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
@@ -55,8 +54,6 @@ import org.fairscan.app.data.ImageRepository
 import org.fairscan.app.ui.Navigation
 import org.fairscan.app.ui.Screen
 import org.fairscan.app.ui.components.rememberCameraPermissionState
-import org.fairscan.app.ui.screens.document.DocumentScreen
-import org.fairscan.app.ui.screens.crop.CropScreen
 import org.fairscan.app.ui.screens.LibrariesScreen
 import org.fairscan.app.ui.screens.ResumeScanScreen
 import org.fairscan.app.ui.screens.about.AboutEvent
@@ -66,6 +63,8 @@ import org.fairscan.app.ui.screens.about.createEmailWithImageIntent
 import org.fairscan.app.ui.screens.camera.CameraEvent
 import org.fairscan.app.ui.screens.camera.CameraScreen
 import org.fairscan.app.ui.screens.camera.CameraViewModel
+import org.fairscan.app.ui.screens.crop.CropScreen
+import org.fairscan.app.ui.screens.document.DocumentScreen
 import org.fairscan.app.ui.screens.export.ExportActions
 import org.fairscan.app.ui.screens.export.ExportEvent
 import org.fairscan.app.ui.screens.export.ExportResult
@@ -178,9 +177,9 @@ class MainActivity : ComponentActivity() {
                     }
                     is Screen.Main.Camera -> {
                         val pickMultiple = rememberLauncherForActivityResult(
-                            ActivityResultContracts.PickMultipleVisualMedia(10)) {
-                            uris -> cameraViewModel.importPhotos(uris)
-                        }
+                            ActivityResultContracts.GetMultipleContents()) {
+                                uris -> cameraViewModel.importPhotos(uris)
+                            }
                         CameraScreen(
                             viewModel,
                             cameraViewModel,
@@ -192,8 +191,7 @@ class MainActivity : ComponentActivity() {
                             cameraPermission = cameraPermission,
                             onImportClicked = {
                                 cameraViewModel.onImportClicked()
-                                pickMultiple.launch(PickVisualMediaRequest(
-                                    ActivityResultContracts.PickVisualMedia.ImageOnly))
+                                pickMultiple.launch("image/*")
                             }
                         )
                     }


### PR DESCRIPTION
To import photos, FairScan currently uses Android photo picker (https://developer.android.com/training/data-storage/shared/photo-picker) through `ActivityResultContracts.PickMultipleVisualMedia`. This opens a system interface where the user can pick photos visually and recent images are shown first. However, finding an image through its path on the file system is currently not possible. That can be a problem for some use cases.

Calling `ActivityResultContracts.GetMultipleContents()` with a MIME type set to `image/*` still opens the photo picker, but it adds a "Browse" option to explore the file system. This looks like an undocumented behavior. A blog post only explains the "GET_CONTENT takeover": https://android-developers.googleblog.com/2023/04/photo-picker-everywhere.html 

On older Android systems, both `PickMultipleVisualMedia` and `GetMultipleContents` display a file explorer.

I tested `GetMultipleContents` on various Android versions from 8.0 to 16 and it seems to work fine.

