### PR TITLE
Reduce false positive quads on import

### DIFF
--- a/app/src/main/java/org/fairscan/app/ui/screens/camera/CameraViewModel.kt
+++ b/app/src/main/java/org/fairscan/app/ui/screens/camera/CameraViewModel.kt
@@ -35,6 +35,7 @@ import org.fairscan.app.AppContainer
 import org.fairscan.app.domain.CapturedPage
 import org.fairscan.app.platform.extractDocumentFromBitmap
 import org.fairscan.imageprocessing.ImageSize
+import org.fairscan.imageprocessing.Mode
 import org.fairscan.imageprocessing.OpticalMeasures
 import org.fairscan.imageprocessing.detectDocumentQuad
 import java.util.concurrent.CancellationException
@@ -112,7 +113,7 @@ class CameraViewModel(appContainer: AppContainer): ViewModel() {
                 val maskSize = segmentation.maskSize()
                 val originalSize = ImageSize(imageProxy.width, imageProxy.height)
                 val rawQuad = withContext(Dispatchers.Default) {
-                    detectDocumentQuad(segmentation, originalSize, isLiveAnalysis = true)
+                    detectDocumentQuad(segmentation, originalSize, Mode.LIVE_ANALYSIS)
                         ?.rotate90(rotationDegrees / 90, maskSize)
                 }
                 val binaryMaskProvider = { ->
@@ -141,7 +142,8 @@ class CameraViewModel(appContainer: AppContainer): ViewModel() {
                 try {
                     val source = imageProxy.toBitmap()
                     val rotationDegrees = imageProxy.imageInfo.rotationDegrees
-                    val page = processCapturedImage(source, rotationDegrees, opticalMeasures)
+                    val page =
+                        processCapturedImage(source, rotationDegrees, opticalMeasures, Mode.CAPTURE)
                     imageProxy.close()
                     onCaptureProcessed(page)
                 } catch (e: RuntimeException) {
@@ -158,11 +160,12 @@ class CameraViewModel(appContainer: AppContainer): ViewModel() {
         source: Bitmap,
         rotationDegrees: Int,
         opticalMeasures: OpticalMeasures?,
+        mode: Mode,
     ): CapturedPage = withContext(Dispatchers.IO) {
         val segmentation = imageSegmentationService.runSegmentationAndReturn(source)
         val mask = segmentation?.segmentation
         val originalSize = ImageSize(source.width, source.height)
-        val quad = mask?.let { detectDocumentQuad(mask, originalSize, isLiveAnalysis = false) }
+        val quad = mask?.let { detectDocumentQuad(mask, originalSize, mode) }
         val defaultColorMode = settingsRepository.defaultColorMode.first()
         val result = extractDocumentFromBitmap(
             source, quad, rotationDegrees, mask, viewModelScope, defaultColorMode, opticalMeasures)
@@ -206,7 +209,7 @@ class CameraViewModel(appContainer: AppContainer): ViewModel() {
                 try {
                     val photoToImport = imageLoader.load(uri)
                     ensureActive()
-                    val page = processCapturedImage(photoToImport, 0, null)
+                    val page = processCapturedImage(photoToImport, 0, null, Mode.IMPORT)
                     ensureActive()
                     _events.emit(CameraEvent.ImageCaptured(page))
                 } catch (e: CancellationException) {

--- a/evaluation/src/main/java/org/fairscan/evaluation/ColorDetectionEvaluator.kt
+++ b/evaluation/src/main/java/org/fairscan/evaluation/ColorDetectionEvaluator.kt
@@ -15,6 +15,7 @@
 package org.fairscan.evaluation
 
 import org.fairscan.imageprocessing.ColorMode
+import org.fairscan.imageprocessing.Mode
 import org.fairscan.imageprocessing.detectDocumentQuad
 import org.fairscan.imageprocessing.extractDocument
 import org.fairscan.imageprocessing.autoColorMode
@@ -59,7 +60,7 @@ object ColorDetectionEvaluator {
 
             val mask = MatMask(maskMat)
 
-            val quad = detectDocumentQuad(mask, mat.size().toImageSize(), isLiveAnalysis = false)
+            val quad = detectDocumentQuad(mask, mat.size().toImageSize(), Mode.CAPTURE)
                 ?.scaledTo(mask.width, mask.height, mat.width(), mat.height())
 
             if (quad == null) continue

--- a/evaluation/src/main/java/org/fairscan/evaluation/DatasetEvaluator.kt
+++ b/evaluation/src/main/java/org/fairscan/evaluation/DatasetEvaluator.kt
@@ -15,6 +15,7 @@
 package org.fairscan.evaluation
 
 import org.fairscan.imageprocessing.Mask
+import org.fairscan.imageprocessing.Mode
 import org.fairscan.imageprocessing.autoColorMode
 import org.fairscan.imageprocessing.detectDocumentQuad
 import org.fairscan.imageprocessing.extractDocument
@@ -70,7 +71,7 @@ object DatasetEvaluator {
             val mask = MatMask(maskMat)
 
             val originalSize = inputMat.size().toImageSize()
-            val quad = detectDocumentQuad(mask, originalSize, isLiveAnalysis = false)
+            val quad = detectDocumentQuad(mask, originalSize, Mode.CAPTURE)
                 ?.scaledTo(mask.width, mask.height, inputMat.width(), inputMat.height())
 
             val corrected = if (quad == null)

--- a/evaluation/src/main/java/org/fairscan/evaluation/ExportQualityEvaluator.kt
+++ b/evaluation/src/main/java/org/fairscan/evaluation/ExportQualityEvaluator.kt
@@ -14,6 +14,7 @@
  */
 package org.fairscan.evaluation
 
+import org.fairscan.imageprocessing.Mode
 import org.fairscan.imageprocessing.detectDocumentQuad
 import org.fairscan.imageprocessing.extractDocument
 import org.fairscan.imageprocessing.autoColorMode
@@ -58,7 +59,7 @@ object ExportQualityEvaluator {
             val mask = MatMask(maskMat)
 
             val originalSize = sourceMat.size().toImageSize()
-            val quad = detectDocumentQuad(mask, originalSize, isLiveAnalysis = false)
+            val quad = detectDocumentQuad(mask, originalSize, Mode.CAPTURE)
                 ?.scaledTo(mask.width, mask.height, sourceMat.width(), sourceMat.height())
             if (quad == null) {
                 println("Failed to detect quad for $imgName")

--- a/evaluation/src/main/java/org/fairscan/evaluation/QuadDetectionEvaluator.kt
+++ b/evaluation/src/main/java/org/fairscan/evaluation/QuadDetectionEvaluator.kt
@@ -15,6 +15,7 @@
 package org.fairscan.evaluation
 
 import nu.pattern.OpenCV
+import org.fairscan.imageprocessing.Mode
 import org.fairscan.imageprocessing.detectDocumentQuad
 import org.fairscan.imageprocessing.scaledTo
 import org.fairscan.imageprocessing.toCv
@@ -65,7 +66,7 @@ object QuadDetectionEvaluator {
             val mask = MatMask(maskMat)
 
             val originalSize = inputMat.size().toImageSize()
-            val quad = detectDocumentQuad(mask, originalSize, isLiveAnalysis = false)
+            val quad = detectDocumentQuad(mask, originalSize, Mode.CAPTURE)
                 ?.scaledTo(mask.width, mask.height, inputMat.width(), inputMat.height())
 
             val inputOut = File(outputDir, "${e.name}_input.jpg")

--- a/imageprocessing/src/main/java/org/fairscan/imageprocessing/DocumentDetection.kt
+++ b/imageprocessing/src/main/java/org/fairscan/imageprocessing/DocumentDetection.kt
@@ -33,14 +33,19 @@ interface Mask {
     fun toMat(): Mat
 }
 
-fun detectDocumentQuad(mask: Mask, originalSize: ImageSize, isLiveAnalysis: Boolean): Quad? {
+enum class Mode {
+    CAPTURE, IMPORT, LIVE_ANALYSIS
+}
+
+fun detectDocumentQuad(mask: Mask, originalSize: ImageSize, mode: Mode): Quad? {
     val mat = mask.toMat()
     // Best thresholds on test dataset: {0.95=146, 0.85=39, 0.75=35, 0.90=8, 0.70=1, 0.35=1}
     val thresholds =
-        if (isLiveAnalysis) listOf(0.9) else listOf(0.5, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95)
+        if (mode != Mode.CAPTURE) listOf(0.9) else listOf(0.5, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95)
     var vertices = findQuadFromOrientationWithAdaptiveThreshold(mat, originalSize, thresholds)
         ?.map { Point(it.x, it.y) }
-    if (vertices == null && !isLiveAnalysis) {
+
+    if (vertices == null && mode == Mode.CAPTURE) {
         // Fallback: bounding rectangle
         val biggest = biggestContour(mat)
         if (biggest != null) {

--- a/imageprocessing/src/main/java/org/fairscan/imageprocessing/quad/ContourOrientation.kt
+++ b/imageprocessing/src/main/java/org/fairscan/imageprocessing/quad/ContourOrientation.kt
@@ -32,7 +32,7 @@ fun findQuadFromContourOrientation(
     smoothWindow: Int = 5,
     maxAngleVar: Double = Math.toRadians(5.0),
     mergeAngle: Double = Math.toRadians(7.0),
-    minSideLengthRatio: Double = 0.02
+    minSideLengthRatio: Double = 0.03
 ): List<Point>? {
 
     if (contour.size < 20) return null


### PR DESCRIPTION
On import, users have no live feedback, so images are more likely to not contain quad edges.
- Remove quad fallbacks on import
- Adjust minSideLengthRatio for all modes